### PR TITLE
Added shape 2d features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+.local/

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "Radiomics"
 uuid = "a80a7044-09a6-4a0a-a486-eb806178b9ba"
-authors = ["Paolo Zaffino <p.zaffino@unicz.it>"]
+authors = ["Paolo Zaffino <p.zaffino@unicz.it>", "Ciro Benito Raggio <ciro.raggio@kit.edu>"]
 version = "0.1.0"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NIfTI = "a3a9e032-41b5-5fc4-967a-a6b7a19844d3"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+LinearAlgebra = "1.11.0"
 NIfTI = "0.6.1"
 StatsBase = "0.34.4"
 Test = "1.11.0"

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -1,20 +1,33 @@
 module Radiomics
 
 include("first_order_features.jl")
+include("shape2D.jl")
 
-function extract_radiomic_features(img_input,
-                                   mask_input,
-                                   voxel_spacing_input;
-                                   verbose::Bool=false)::Dict{String, Float32}
 
-    println("Extracting...")
+function extract_radiomic_features(img_input, mask_input, voxel_spacing_input; force_2d::Bool=false, force_2d_dimension::Int=1, verbose::Bool=false)::Dict{String, Float32}
+    """
+    Extracts radiomic features from the given image and mask inputs. 
+    In case of two-dimensional input, 2D features will be extracted and returned for the single slice.
+
+    # Arguments
+    - `img_input`: The input image from which radiomic features will be extracted. Can be 2D or 3D.
+    - `mask_input`: The mask image defining the region of interest for feature extraction. Can be 2D or 3D.
+    - `voxel_spacing_input`: A tuple or array specifying the voxel spacing of the input image. Can be bidimensional or three-dimensional.
+    - `force_2d::Bool`: If `true`, forces the extraction to be performed in 2D by removing one dimension from the voxel spacing. This is useful when the input data is three-dimensional but should be treated as two-dimensional.
+    - `force_2d_dimension::Int`: Specifies which dimension to eliminate when `force_2d` is `true`. For example, if set to `1`, the first dimension will be removed.
+    - `verbose::Bool`: If `true`, enables verbose output for debugging or detailed processing information.
+
+    # Returns
+    A dictionary (`Dict{String, Float32}`) containing the extracted radiomic features as key-value pairs.
+    """
+    if verbose
+        println("Extracting...")
+    end
 
     radiomic_features = Dict{String, Float32}()
 
     # Cast inputs
-    img::Array{Float32, 3} = Float32.(img_input)
-    mask::BitArray{3} = BitArray(mask_input .!= 0.0f0)
-    voxel_spacing::Vector{Float32} = Float32.(voxel_spacing_input)
+    img, mask, voxel_spacing = prepare_inputs(img_input, mask_input, voxel_spacing_input, force_2d, force_2d_dimension)
 
     # Sanity check on inputs
     sanity_check_start_time::Float64 = time()
@@ -23,16 +36,44 @@ function extract_radiomic_features(img_input,
         println("Sanity check time = $(time() - sanity_check_start_time)")
     end
 
-    # First order features
-    first_order_start_time::Float64 = time()
-    first_order_features::Dict{String, Float32} = get_first_order_features(img, mask, voxel_spacing, verbose)
-    merge!(radiomic_features, first_order_features)
-    if verbose
-        println("First order time = $(time() - first_order_start_time)")
+    # Extract features
+    if ndims(img) == 3
+        # First order features
+        first_order_start_time::Float64 = time()
+        first_order_features::Dict{String, Float32} = get_first_order_features(img, mask, voxel_spacing, verbose)
+        merge!(radiomic_features, first_order_features)
+        if verbose
+            println("First order time = $(time() - first_order_start_time)")
+        end
     end
 
+    if ndims(mask) == 2
+        shape_2d_start_time::Float64 = time()
+        shape_2d_features::Dict{String, Float32} = get_shape2d_features(mask, voxel_spacing, verbose)
+        merge!(radiomic_features, shape_2d_features)
+        if verbose
+            println("2D shape time = $(time() - shape_2d_start_time)")
+        end
+    end 
+    
     return radiomic_features
 
+end
+
+function prepare_inputs(img_input, mask_input, voxel_spacing_input, force_2d, force_2d_dimension)
+    img = Float32.(img_input)
+    mask = BitArray(mask_input .!= 0.0f0)
+    
+    voxel_spacing = Float32.(voxel_spacing_input)
+
+    if ndims(img) == 3 && ndims(mask) == 3 && force_2d
+        if force_2d_dimension < 1 || force_2d_dimension > 3
+            throw(ArgumentError("force_2d_dimension must be between 1 and 3"))
+        end
+        voxel_spacing = Float32.(voxel_spacing_input[setdiff(1:3, force_2d_dimension)])
+    end
+    print(ndims(img), ndims(mask), force_2d, force_2d_dimension)
+    return img, mask, voxel_spacing
 end
 
 
@@ -42,7 +83,9 @@ function input_sanity_check(img, mask, verbose::Bool)
         println("Running input sanity check...")
     end
 
-    @assert size(img) == size(mask) "img and mask have different size!"
+    if size(img) != size(mask)
+        throw(ArgumentError("img and mask have different size!"))
+    end
 
 end
 

--- a/src/shape2D.jl
+++ b/src/shape2D.jl
@@ -1,0 +1,238 @@
+using LinearAlgebra
+
+#=
+  RadiomicsShape2D: 2D shape features extraction
+=##
+
+function get_shape2d_features(mask_array::BitArray{2}, spacing::Vector{Float32}, verbose::Bool=false)
+    if verbose
+        println("Extracting 2D shape features...")
+    end
+
+    features = Dict{String, Float32}()
+
+    perimeter, surface, diameter = get_coefficients(mask_array, spacing)
+
+    # Perimeter
+    features["shape2d_perimeter"] = perimeter
+
+    # Mesh Surface
+    features["shape2d_mesh_surface"] = surface
+
+    # Maximum 2D Diameter
+    features["shape2d_maximum_diameter"] = diameter
+
+    # Pixel Surface
+    features["shape2d_pixel_surface"] = get_pixel_surface(mask_array, spacing)
+
+    # Perimeter Surface Ratio
+    features["shape2d_perimeter_surface_ratio"] = get_perimeter_surface_ratio(perimeter, surface)
+
+    # Sphericity
+    features["shape2d_sphericity"] = get_sphericity(perimeter, surface)
+
+    ev = get_eigenvalues(mask_array, spacing)
+
+    # Major Axis Length
+    features["shape2d_major_axis_length"] = get_major_axis_length(ev)
+
+    # Minor Axis Length
+    features["shape2d_minor_axis_length"] = get_minor_axis_length(ev)
+
+    # Elongation
+    features["shape2d_elongation"] = get_elongation(ev)
+
+    if verbose
+        for (k, v) in features
+            println("  $k = $v")
+        end
+    end
+
+    return features
+end
+
+function get_perimeter_surface_ratio(perimeter::Float32, surface::Float32)::Float32
+    return Float32(perimeter / surface)
+end
+
+function get_sphericity(perimeter::Float32, surface::Float32)::Float32
+    return Float32((2 * sqrt(pi * surface)) / perimeter)
+end
+
+function get_eigenvalues(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float32})::Vector{Float32}
+    coords = Iterators.filter(i -> mask[i], CartesianIndices(mask))
+    Np = count(_ -> true, coords)
+
+    if Np == 0
+        return zeros(Float32, 2)
+    end
+
+    offset_x = (0:size(mask, 1)-1) .* spacing[1]
+    offset_y = (0:size(mask, 2)-1) .* spacing[2]
+
+    points = [(offset_x[c[1]], offset_y[c[2]]) for c in coords]
+
+    if isempty(points)
+        return zeros(Float32, 2)
+    end
+
+    xs = Float64[x for (x, _) in points]
+    ys = Float64[y for (_, y) in points]
+
+    meanx = mean(xs)
+    meany = mean(ys)
+
+    centered = hcat(xs .- meanx, ys .- meany)
+
+    covmat = centered' * centered / Np
+
+    eigvals = eigen(covmat).values
+
+    return Float32.(sort(eigvals, rev=false))
+end
+
+
+
+
+function get_pixel_surface(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float32})::Float32
+    return Float32(count(mask) * (spacing[1] * spacing[2]))
+end
+
+function get_major_axis_length(ev::Vector{Float32})::Float32
+    """
+    Major axis length is calculated as 4 * sqrt(eigenvalue[2])
+    where eigenvalue[2] is the second largest eigenvalue of the covariance matrix.
+    This is a measure of the size of the shape in the direction of its major axis.
+    """
+    return ev[2] >= 0 ? Float32(4*sqrt(ev[2])) : NaN
+end
+
+function get_minor_axis_length(ev::Vector{Float32})::Float32
+    """
+    Minor axis length is calculated as 4 * sqrt(eigenvalue[1])
+    where eigenvalue[1] is the smallest eigenvalue of the covariance matrix.
+    This is a measure of the size of the shape in the direction of its minor axis.
+    """
+    return ev[1] >= 0 ? Float32(4*sqrt(ev[1])) : NaN
+end
+
+function get_elongation(ev::Vector{Float32})::Float32
+    """
+    Elongation is calculated as the ratio of the major axis length to the minor axis length.
+    This is a measure of how elongated the shape is.
+    """
+    return Float32(sqrt(ev[1]/ev[2]))
+end
+
+"""
+Helper functions to calculate the maximum diameter of a 2D mesh and coefficients for the 2D shape
+Original C code: https://github.com/AIM-Harvard/pyradiomics/blob/master/radiomics/src/cshape.c
+"""
+function calculate_mesh_diameter2d(points::Vector{Float64})
+    diameter = 0.0
+    stack_top = length(points)
+    while stack_top > 0
+        y1 = points[stack_top]; stack_top -= 1
+        x1 = points[stack_top]; stack_top -= 1
+        for i in 1:2:stack_top
+            x2, y2 = points[i], points[i+1]
+            dx = x1 - x2
+            dy = y1 - y2
+            dist2 = dx^2 + dy^2
+            if dist2 > diameter
+                diameter = dist2
+            end
+        end
+    end
+    return sqrt(diameter)
+end
+
+function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float32})::Tuple{Float32, Float32, Float32}
+    perimeter = 0.0
+    surface = 0.0
+
+    # lookup tables
+    grid_angles_2d = ((0,0), (0,1), (1,1), (1,0))
+    
+    line_table_2d = [
+        (-1, -1, -1, -1, -1),
+        ( 3,  0, -1, -1, -1),
+        ( 0,  1, -1, -1, -1),
+        ( 3,  1, -1, -1, -1),
+        ( 1,  2, -1, -1, -1),
+        ( 1,  2,  3,  0, -1),
+        ( 0,  2, -1, -1, -1),
+        ( 3,  2, -1, -1, -1),
+        ( 2,  3, -1, -1, -1),
+        ( 2,  0, -1, -1, -1),
+        ( 0,  1,  2,  3, -1),
+        ( 2,  1, -1, -1, -1),
+        ( 1,  3, -1, -1, -1),
+        ( 1,  0, -1, -1, -1),
+        ( 0,  3, -1, -1, -1),
+        (-1, -1, -1, -1, -1),
+    ]
+
+    vert_list_2d = [
+        (0.0, 0.5), (0.5, 1.0), (1.0, 0.5), (0.5, 0.0)
+    ]
+    points_edges = ((0, 2), (3, 2))
+
+    ny, nx = size(mask)  # Automatically get the size of the mask
+    vertices = Float64[]
+    
+    for iy in 1:(ny - 1)
+        for ix in 1:(nx - 1)
+            square_idx = 0
+            for a_idx in 1:4
+                dy, dx = grid_angles_2d[a_idx]
+                y = iy + dy
+                x = ix + dx
+                if 1 <= y <= ny && 1 <= x <= nx
+                    if mask[y, x] != 0
+                        square_idx |= 1 << (a_idx - 1)
+                    end
+                end
+            end
+
+            if square_idx == 0 || square_idx == 0xF
+                continue
+            end
+
+            t = 1
+            while line_table_2d[square_idx + 1][t * 2 - 1] >= 0
+                a = [iy - 1.0, ix - 1.0]
+                b = copy(a)
+                for d in 1:2
+                    a[d] += vert_list_2d[line_table_2d[square_idx + 1][t * 2 - 1] + 1][d]
+                    b[d] += vert_list_2d[line_table_2d[square_idx + 1][t * 2] + 1][d]
+                    a[d] *= spacing[d]
+                    b[d] *= spacing[d]
+                end
+
+                # Surface (cross product z)
+                surface += (a[1]*b[2]) - (b[1]*a[2])
+
+                # Perimeter (Euclidean distance)
+                dist = sqrt((a[1] - b[1])^2 + (a[2] - b[2])^2)
+                perimeter += dist
+                t += 1
+            end
+
+            # Save points for diameter
+            if square_idx > 7
+                square_idx ⊻= 0xF
+            end
+            for t in 1:2
+                if square_idx & (1 << points_edges[1][t]) != 0
+                    push!(vertices, ((iy - 1) + vert_list_2d[points_edges[2][t] + 1][1]) * spacing[1])
+                    push!(vertices, ((ix - 1) + vert_list_2d[points_edges[2][t] + 1][2]) * spacing[2])
+                end
+            end
+        end
+    end
+
+    surface /= 2.0
+    diameter = calculate_mesh_diameter2d(vertices)
+    return Float32(perimeter), Float32(surface), Float32(diameter)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using NIfTI
 using Radiomics
 
-@testset "Radiomics test" begin
+@testset "Radiomics test - First Order Features" begin
 
     ct = niread("../sample_data/CTChest.nii.gz")
     mask = niread("../sample_data/Lungs.nii.gz")
@@ -30,5 +30,36 @@ using Radiomics
     @test isapprox(radiomic_features["firstorder_robust_mean_absolute_deviation"] , 23.399605f0; rtol=3e-4)
     @test isapprox(radiomic_features["firstorder_kurtosis"]                       , 5.393815f0; rtol=1e-4)
     @test isapprox(radiomic_features["firstorder_maximum"]                        , -653.0f0; atol=1e-4)
-
 end
+
+@testset "Radiomics test - Shape2D Features" begin
+
+    ct = niread("../sample_data/CTChest.nii.gz")
+    mask = niread("../sample_data/Lungs.nii.gz")
+    spacing = [ct.header.pixdim[2], ct.header.pixdim[3], ct.header.pixdim[4]]
+
+    # Extract a single slice for Shape2D features
+
+    slice_idx = 51
+    """
+    Python equivalent using SimpleITK to reproduce the results:
+    ct_slice = sitk.GetImageFromArray(sitk.GetArrayFromImage(ct)[slice_idx-1,:,:])
+    mask_slice = sitk.GetImageFromArray(sitk.GetArrayFromImage(mask)[slice_idx-1,:,:])
+    """
+    ct_slice = ct.raw[:, :, slice_idx]
+    mask_slice = mask.raw[:, :, slice_idx]
+
+
+    radiomic_features = Radiomics.extract_radiomic_features(ct_slice, mask_slice, spacing; force_2d=true, force_2d_dimension=2, verbose = false)
+
+    @test isapprox(radiomic_features["shape2d_elongation"]                        , 0.6524707f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_major_axis_length"]                 , 271.63801f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_maximum_diameter"]                  , 242.68498f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_mesh_surface"]                      , 26619.75f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_minor_axis_length"]                 , 177.23585f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_perimeter"]                         , 2146.99826f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_perimeter_surface_ratio"]           , 0.08065f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_pixel_surface"]                     , 26556.75f0; atol=1e-4)
+    @test isapprox(radiomic_features["shape2d_sphericity"]                        , 0.269386f0; atol=1e-4)
+
+    end


### PR DESCRIPTION
- The entry point checks the dimensionality of the input. If the input is 2D, 2d shape features will be added to the feature dictionary.
- The test group has been separated, and all tests have passed with a tolerance of 1e-4.
- I replaced an assert with a true condition for a more robust, non-avoidable test.

Some of the code was developed according to the PyRadiomics guidelines. In particular, the functions `calculate_mesh_diameter2d` and `get_coefficients` were translated from a C module (https://github.com/AIM-Harvard/pyradiomics/blob/master/radiomics/src/cshape.c), including LUT. I updated the references in the code.