### PR TITLE
Optimization radiomicsjl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,6 @@ function parse_args_custom()\n\
             help = "Return raw feature matrices"\n\
             arg_type = Bool\n\
             default = false\n\
-        "--sample_rate"\n\
-            help = "Sample rate for feature extraction"\n\
-            arg_type = Float64\n\
-            default = 0.03\n\
         "--verbose"\n\
             help = "Enable verbose output"\n\
             arg_type = Bool\n\
@@ -87,7 +83,6 @@ features = Radiomics.extract_radiomic_features(\n\
     weighting_norm=args["weighting_norm"],\n\
     keep_largest_only=args["keep_largest_only"],\n\
     get_raw_matrices=args["get_raw_matrices"],\n\
-    sample_rate=args["sample_rate"],\n\
     slices_2d=nothing,\n\
     verbose=args["verbose"]\n\
 );\n\

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 JSON3 = "1.14.3"

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ docker run -it -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii
 ```
 Run the container with custom parameters.
 ```bash
-docker run -it -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz --keep_largest_only false --sample_rate 1.0
+docker run -it -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz --keep_largest_only false
 ```
 Run the container with multi-threading enabled.
 ```bash
-docker run -it -e JULIA_NUM_THREADS=auto -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz --keep_largest_only false --sample_rate 1.0
+docker run -it -e JULIA_NUM_THREADS=auto -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz --keep_largest_only false
 ```
 # Discalaimer
 This software is for research purposes only.

--- a/docs/2d-shape.html
+++ b/docs/2d-shape.html
@@ -795,7 +795,7 @@
         <div class="info-box">
           <ul>
             <li><code>mask_array</code>: A 2D binary array (BitArray) representing the shape region of interest</li>
-            <li><code>spacing</code>: A vector of <code>Float32</code> values indicating the pixel spacing in each
+            <li><code>spacing</code>: A vector of <code>Float64</code> values indicating the pixel spacing in each
               dimension</li>
             <li><code>verbose</code>: A Boolean flag to enable progress messages during computation</li>
           </ul>

--- a/docs/cross_languages.html
+++ b/docs/cross_languages.html
@@ -934,11 +934,11 @@ lib.init_julia(<span class="julia-literal">0</span>, <span class="julia-literal"
 
 <span class="julia-comment"># Define function signatures</span>
 lib.c_extract_radiomic_features.argtypes = [
-    ctypes.POINTER(ctypes.c_float),  <span class="julia-comment"># img_ptr   (Float32)</span>
+    ctypes.POINTER(ctypes.c_float),  <span class="julia-comment"># img_ptr   (Float64)</span>
     ctypes.c_int64,                  <span class="julia-comment"># size_x    (Int64)</span>
     ctypes.c_int64,                  <span class="julia-comment"># size_y    (Int64)</span>
     ctypes.c_int64,                  <span class="julia-comment"># size_z    (Int64)</span>
-    ctypes.POINTER(ctypes.c_float),  <span class="julia-comment"># mask_ptr  (Float32)</span>
+    ctypes.POINTER(ctypes.c_float),  <span class="julia-comment"># mask_ptr  (Float64)</span>
     ctypes.c_double,                 <span class="julia-comment"># spacing_x (Float64)</span>
     ctypes.c_double,                 <span class="julia-comment"># spacing_y (Float64)</span>
     ctypes.c_double,                 <span class="julia-comment"># spacing_z (Float64)</span>
@@ -952,8 +952,8 @@ ct_sitk = sitk.ReadImage(<span class="julia-string">'DATA_PATH/CT.nrrd'</span>)
 mask_sitk = sitk.ReadImage(<span class="julia-string">'DATA_PATH/left_parotid.nrrd'</span>)
 
 <span class="julia-comment"># Convert to numpy arrays (Fortran-contiguous)</span>
-ct = np.asfortranarray(sitk.GetArrayFromImage(ct_sitk), dtype=np.float32)
-mask = np.asfortranarray(sitk.GetArrayFromImage(mask_sitk), dtype=np.float32)
+ct = np.asfortranarray(sitk.GetArrayFromImage(ct_sitk), dtype=np.Float64)
+mask = np.asfortranarray(sitk.GetArrayFromImage(mask_sitk), dtype=np.Float64)
 
 <span class="julia-comment"># Get data pointers</span>
 ptr_ct = ct.ctypes.data_as(ctypes.POINTER(ctypes.c_float))

--- a/docs/cross_languages.html
+++ b/docs/cross_languages.html
@@ -1333,7 +1333,7 @@ features &lt;- radiomics$extract_radiomic_features(ct_clean, mask_clean, spacing
                             <span class="code-dot"></span>
                             <span class="code-dot"></span>
                         </div>
-                        <pre><code>docker run -it -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz <span class="julia-keyword">--keep_largest_only</span> false <span class="julia-keyword">--sample_rate</span> 1.0</code></pre>
+                        <pre><code>docker run -it -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz <span class="julia-keyword">--keep_largest_only</span> false</code></pre>
                     </div>
 
                     <h4 style="font-size: 1.1rem; margin-top: 24px; margin-bottom: 12px;">Multi-threading</h4>
@@ -1344,7 +1344,7 @@ features &lt;- radiomics$extract_radiomic_features(ct_clean, mask_clean, spacing
                             <span class="code-dot"></span>
                             <span class="code-dot"></span>
                         </div>
-                        <pre><code>docker run -it <span class="julia-keyword">-e</span> JULIA_NUM_THREADS=auto -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz <span class="julia-keyword">--keep_largest_only</span> false <span class="julia-keyword">--sample_rate</span> 1.0</code></pre>
+                        <pre><code>docker run -it <span class="julia-keyword">-e</span> JULIA_NUM_THREADS=auto -v $(pwd):/data ghcr.io/pzaffino/radiomics.jl:latest /data/ct.nii.gz /data/mask.nii.gz <span class="julia-keyword">--keep_largest_only</span> false</code></pre>
                     </div>
 
                 </div>

--- a/docs/example.html
+++ b/docs/example.html
@@ -602,7 +602,6 @@
                           weighting_norm<span class="julia-keyword">=</span><span class="julia-literal">nothing</span>,
                           keep_largest_only<span class="julia-keyword">::</span><span class="julia-type">Bool</span><span class="julia-keyword">=</span><span class="julia-literal">true</span>,
                           get_raw_matrices<span class="julia-keyword">::</span><span class="julia-type">Bool</span><span class="julia-keyword">=</span><span class="julia-literal">false</span>,
-                          sample_rate<span class="julia-keyword">=</span><span class="julia-literal">0.03</span>,
                           slices_2d<span class="julia-keyword">=</span><span class="julia-literal">nothing</span>,
                           verbose<span class="julia-keyword">::</span><span class="julia-type">Bool</span><span class="julia-keyword">=</span><span class="julia-literal">false</span>)
 
@@ -621,7 +620,6 @@
 <span class="julia-comment">#  weighting_norm      – Norm used for GLCM distance weighting.</span>
 <span class="julia-comment">#  keep_largest_only   – If true, only the largest connected component is used.</span>
 <span class="julia-comment">#  get_raw_matrices    – If true, returns the raw matrices for texture features.</span>
-<span class="julia-comment">#  sample_rate         – Fraction of voxel pairs sampled for GLCM (0–1).</span>
 <span class="julia-comment">#  slices_2d           – If present, calculate all features on 2D slices - mask. When this parameter is used you can pass 
                             a vector of tuples (plan, slice_idx) where plan is the plane number (1, 2, or 3) and slice_idx is the slice index.</span>
 <span class="julia-comment">#  verbose             – Print progress information during extraction.</span>
@@ -786,7 +784,7 @@ ct   = <span class="julia-function">niread</span>(<span class="julia-string">"sa
 mask = <span class="julia-function">niread</span>(<span class="julia-string">"sample_data/Lungs.nii.gz"</span>)
 spacing = [ct.header.pixdim[<span class="julia-literal">2</span>], ct.header.pixdim[<span class="julia-literal">3</span>], ct.header.pixdim[<span class="julia-literal">4</span>]]
 
-features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; sample_rate = 1.0, verbose = true, <span class="julia-literal">keep_largest_only=false</span>)</code></pre>
+features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; verbose = true, <span class="julia-literal">keep_largest_only=false</span>)</code></pre>
                 </div>
             </div>
             <!-- SNIPPET 7 -->
@@ -807,7 +805,7 @@ ct   = <span class="julia-function">niread</span>(<span class="julia-string">"sa
 mask = <span class="julia-function">niread</span>(<span class="julia-string">"sample_data/Lungs.nii.gz"</span>)
 spacing = [ct.header.pixdim[<span class="julia-literal">2</span>], ct.header.pixdim[<span class="julia-literal">3</span>], ct.header.pixdim[<span class="julia-literal">4</span>]]
 
-features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; sample_rate = 1.0, verbose = true, keep_largest_only=false, <span class="julia-literal">weighting_norm="euclidean"</span>);</code></pre>
+features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; verbose = true, keep_largest_only=false, <span class="julia-literal">weighting_norm="euclidean"</span>);</code></pre>
                 </div>
             </div>
 

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -24,7 +24,6 @@ include("diagnostic_features.jl")
                               bin_width=nothing,
                               weighting_norm=nothing,
                               keep_largest_only::Bool=true,
-                              sample_rate=0.03,
                               get_raw_matrices::Bool=false,
                               slices_2d=nothing,
                               verbose::Bool=false)
@@ -45,7 +44,6 @@ include("diagnostic_features.jl")
     - `weighting_norm`: Performs weight-normalized radiomic feature extraction on the input image and mask (optional).
                         Options: "infinity", "euclidean", "manhattan", and "no_weighting".
     - `keep_largest_only`: If true, keeps only the largest connected component for 3D shape features (default: true).
-    - `sample_rate`: The sample rate for feature extraction (optional).
     - `get_raw_matrices`: If true, computes raw (unnormalized, unweighted) GLCM matrices along all directions
                            and stores them in the result as `"get_raw_matrices"` (Vector of Matrix{Float64}).
     - `slices_2d`: If present, calcule all features on 2d slice - mask, when this parameter is used you can pass 
@@ -63,14 +61,12 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     bin_width::Union{Nothing,Float64}=nothing,
     weighting_norm::Union{Nothing,String}=nothing,
     keep_largest_only::Bool=true,
-    sample_rate::Float64=0.03,
     get_raw_matrices::Bool=false,
     slices_2d=nothing,
     verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}, Dict{Tuple{Int,Int},Any}}
 
     # Convert parameters to correct types
     bin_width = isnothing(bin_width) ? nothing : Float64(bin_width)
-    sample_rate = Float64(sample_rate)
     
     # Convert features (supports String, Vector{String}, Symbol, Vector{Symbol})
     if features isa String
@@ -167,7 +163,6 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 bin_width=bin_width,
                 weighting_norm=weighting_norm,
                 keep_largest_only=keep_largest_only,
-                sample_rate=sample_rate,
                 get_raw_matrices=get_raw_matrices,
                 verbose=verbose
             )
@@ -233,9 +228,6 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 else
                     push!(log_buffer, "Using bin_width = $bin_width")
                 end
-                if sample_rate != 0.03
-                    push!(log_buffer, "Using explicit sample_rate = $sample_rate")
-                end
                 if keep_largest_only
                     push!(log_buffer, "keep_largest_only = true (will be applied to selected label)")
                 end
@@ -251,7 +243,6 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                         bin_width=bin_width,
                         weighting_norm=weighting_norm,
                         verbose=verbose,
-                        sample_rate=sample_rate,
                         keep_largest_only=keep_largest_only,
                         compute_all=compute_all,
                         features=features,
@@ -268,7 +259,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                     push!(log_buffer, "Real time (end-to-end): $(total_time_real) sec")
                     push!(log_buffer, "Overhead: $(total_time_real - total_time_accumulated) sec")
                     
-                    diagnosis_features = get_diagnosis_features(sample_rate, bin_width, voxel_spacing_input, total_time_real, 
+                    diagnosis_features = get_diagnosis_features(bin_width, voxel_spacing_input, total_time_real, 
                                             weighting_norm, n_bins, keep_largest_only,
                                             img_input, img_to_use, mask_input, mask_to_use)
                     merge!(radiomic_features, diagnosis_features)
@@ -368,9 +359,6 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         else
             println("Using default bin width: 25.0")
         end
-        if sample_rate != 0.03
-            println("Using explicit sample_rate = $sample_rate")
-        end
         if keep_largest_only
             println("keep_largest_only = true (will be applied to selected label)")
         end
@@ -384,7 +372,6 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         bin_width=bin_width,
         weighting_norm=weighting_norm,
         verbose=verbose,
-        sample_rate=sample_rate,
         keep_largest_only=keep_largest_only,
         compute_all=compute_all,
         features=features,
@@ -399,7 +386,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         println("Measured time of single function'sum (sum of @timed): $(total_time_accumulated) sec")
         println("Real time (end-to-end): $(total_time_real) sec")
         println("Overhead: $(total_time_real - total_time_accumulated) sec")
-        diagnosis_features = get_diagnosis_features(sample_rate, bin_width, voxel_spacing_input, total_time_real, 
+        diagnosis_features = get_diagnosis_features(bin_width, voxel_spacing_input, total_time_real, 
                                                     weighting_norm, n_bins, keep_largest_only,
                                                     img_input, img_to_use, mask_input, mask_to_use)
         merge!(radiomic_features, diagnosis_features)
@@ -419,7 +406,7 @@ end
 """
     _compute_radiomics_impl(img, mask, voxel_spacing; 
                            n_bins, bin_width,
-                           weighting_norm, verbose, sample_rate, 
+                           weighting_norm, verbose, 
                            keep_largest_only, compute_all, features, log_buffer)
     
     Internal function that handles parallel computation of radiomic features.
@@ -434,7 +421,6 @@ end
     - `bin_width`: Bin width
     - `weighting_norm`: Weighting norm for features
     - `verbose`: Print progress messages
-    - `sample_rate`: Sample rate for shape features
     - `keep_largest_only`: Keep only largest connected component
     - `compute_all`: Compute all features or only selected ones
     - `features`: Vector of feature symbols to compute
@@ -448,7 +434,6 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     bin_width::Union{Nothing,Float64}=nothing,
     weighting_norm::Union{Nothing,String}=nothing,
     verbose::Bool=false,
-    sample_rate::Float64=0.03,
     keep_largest_only::Bool=true,
     compute_all::Bool=true,
     features::Vector{Symbol}=Symbol[],
@@ -568,7 +553,6 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
                 result = @timed get_shape3d_features(
                     mask, voxel_spacing;
                     verbose=verbose,
-                    sample_rate=sample_rate,
                     keep_largest_only=keep_largest_only
                 )
                 (result.value, result.time)
@@ -756,7 +740,6 @@ end
         # --- Default bin_width ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            sample_rate       = 1.0,
             keep_largest_only = false,
             verbose           = false
         )
@@ -765,7 +748,6 @@ end
         extract_radiomic_features(
             img_small, mask_small, spacing;
             n_bins            = 32,
-            sample_rate       = 1.0,
             keep_largest_only = false,
             verbose           = false
         )
@@ -774,7 +756,6 @@ end
         extract_radiomic_features(
             img_small, mask_small, spacing;
             bin_width         = 25.0,
-            sample_rate       = 1.0,
             keep_largest_only = false,
             verbose           = false
         )
@@ -784,7 +765,6 @@ end
             extract_radiomic_features(
                 img_small, mask_small, spacing;
                 weighting_norm    = wn,
-                sample_rate       = 1.0,
                 keep_largest_only = false,
                 verbose           = false
             )
@@ -805,7 +785,6 @@ end
             extract_radiomic_features(
                 img_small, mask_small, spacing;
                 features          = feat,
-                sample_rate       = 1.0,
                 keep_largest_only = false,
                 verbose           = false
             )
@@ -814,7 +793,6 @@ end
         # --- keep_largest_only = true ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            sample_rate       = 1.0,
             keep_largest_only = true,
             verbose           = false
         )
@@ -823,7 +801,6 @@ end
         extract_radiomic_features(
             img_small, mask_multi, spacing;
             labels            = [1, 2],
-            sample_rate       = 1.0,
             keep_largest_only = false,
             verbose           = false
         )
@@ -832,7 +809,6 @@ end
         extract_radiomic_features(
             img_small, mask_small, spacing;
             labels            = 1,
-            sample_rate       = 1.0,
             keep_largest_only = false,
             verbose           = false
         )
@@ -841,7 +817,6 @@ end
         extract_radiomic_features(
             img_small, mask_small, spacing;
             get_raw_matrices  = true,
-            sample_rate       = 1.0,
             keep_largest_only = false,
             verbose           = false
         )
@@ -850,7 +825,6 @@ end
         extract_radiomic_features(
             img_small, mask_small, spacing;
             slices_2d         = [(1, 5)],
-            sample_rate       = 1.0,
             keep_largest_only = true,
             verbose           = false
         )
@@ -885,15 +859,12 @@ end
     # Compute all texture features (uses default label=1)
     features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; 
                                         features=[:glcm, :glszm, :glrlm, :gldm, :ngtdm], verbose=true);
-    
-    # Compute with sample_rate personalized (uses default label=1)
-    features = Radiomics.extract_radiomic_features(img, mask, spacing; sample_rate=1.0, verbose=true)
-
+                                        
     # Compute with keep_largest_only personalized (uses default label=1)
-    features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; sample_rate = 1.0, verbose = true, keep_largest_only=false);
+    features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose = true, keep_largest_only=false);
 
     # Compute with weighting_norm personalized (uses default label=1)
-    features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; sample_rate = 1.0, verbose = true, weighting_norm="euclidean");
+    features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose = true, weighting_norm="euclidean");
     
     # Extract features for a specific label (e.g., label 2)
     features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; labels=2, verbose=true);
@@ -901,7 +872,6 @@ end
     # Extract features for multiple labels in parallel
     results = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; 
                                         labels=[1, 2, 30], 
-                                        sample_rate=1.0, 
                                         verbose=true, 
                                         keep_largest_only=true);
     # Access features for label 1: results[1]

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -112,6 +112,8 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
 
     compute_all = isempty(features) || :all in features
 
+    img_input, mask_input, voxel_spacing_input = prepare_inputs(img_input, mask_input, voxel_spacing_input)
+
     # Management slices_2d
     if !isnothing(slices_2d)
         results_2d = Dict{Tuple{Int,Int}, Any}()
@@ -200,14 +202,14 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         
         # Parallelize label processing with log buffering
         tasks = map(labels) do label
-            Threads.@spawn begin
+            Threads.@spawn let label = label
                 # Buffer for logs of this label
                 log_buffer = String[]
                 
                 push!(log_buffer, "\n=== Processing LABEL $label ===")
                 
                 # Create binary mask for the current label
-                mask_to_use, voxel_count = extract_and_check_mask(mask_input, label)
+                local mask_to_use, voxel_count = extract_and_check_mask(mask_input, label)
                 # Check if label exists
                 if voxel_count == 0
                     lock(results_lock) do
@@ -215,8 +217,12 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                     end
                     return nothing
                 end
-                
+
                 push!(log_buffer, "Label $label contains $voxel_count voxels")
+                push!(log_buffer, "Applying bounding box to Label $label...")
+                local img_to_use
+                img_to_use, mask_to_use = bounding_box(img_input, mask_to_use, verbose; log_buffer=log_buffer)
+                
                 if compute_all
                     push!(log_buffer, "Computing ALL features")
                 else
@@ -240,7 +246,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
 
                     # Compute radiomic features passing the log_buffer
                     radiomic_features, time_acc = _compute_radiomics_impl(
-                        img_input, mask_to_use, voxel_spacing_input, voxel_count;
+                        img_to_use, mask_to_use, voxel_spacing_input, voxel_count;
                         n_bins=n_bins,
                         bin_width=bin_width,
                         weighting_norm=weighting_norm,
@@ -264,7 +270,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                     
                     diagnosis_features = get_diagnosis_features(sample_rate, bin_width, voxel_spacing_input, total_time_real, 
                                             weighting_norm, n_bins, keep_largest_only,
-                                            img_input, mask_to_use)
+                                            img_input, img_to_use, mask_input, mask_to_use)
                     merge!(radiomic_features, diagnosis_features)
                     
                     # Print diagnosis features to buffer
@@ -340,6 +346,8 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     if verbose
         println("Label $label contains $voxel_count voxels")
     end
+
+    img_to_use, mask_to_use = bounding_box(img_input, mask_to_use, verbose)
         
     total_start_time = time()
     total_time_accumulated = 0.0 
@@ -371,7 +379,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     # Compute radiomic features using the internal implementation
     # Do NOT pass log_buffer here (uses default =nothing for direct printing)
     radiomic_features, time_acc = _compute_radiomics_impl(
-        img_input, mask_to_use, voxel_spacing_input, voxel_count;
+        img_to_use, mask_to_use, voxel_spacing_input, voxel_count;
         n_bins=n_bins,
         bin_width=bin_width,
         weighting_norm=weighting_norm,
@@ -393,7 +401,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         println("Overhead: $(total_time_real - total_time_accumulated) sec")
         diagnosis_features = get_diagnosis_features(sample_rate, bin_width, voxel_spacing_input, total_time_real, 
                                                     weighting_norm, n_bins, keep_largest_only,
-                                                    img_input, mask_to_use)
+                                                    img_input, img_to_use, mask_input, mask_to_use)
         merge!(radiomic_features, diagnosis_features)
         print_features_diagnosis("Diagnosis Features", diagnosis_features)
         println("---------------------")
@@ -461,9 +469,6 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     
     # Sanity check
     input_sanity_check(img, mask, verbose)
-
-    # Cast and prepare inputs
-    img, mask, voxel_spacing = prepare_inputs(img, mask, voxel_spacing)
 
     # Validate binning parameters
     if isnothing(n_bins) && !isnothing(bin_width) && voxel_count > 0
@@ -685,8 +690,7 @@ Base.@ccallable function c_extract_radiomic_features(
     img_size_x::Int64, img_size_y::Int64, img_size_z::Int64,
     mask_ptr::Ptr{Float64},
     spacing_x::Float64, spacing_y::Float64, spacing_z::Float64,
-    binWidth::Float64
-)::Cstring
+    binWidth::Float64)::Cstring
     global LAST_JSON_RESULT
     try
         # Prepare inputs for the main function

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -57,16 +57,16 @@ include("diagnostic_features.jl")
     - Multiple labels: Dict{Int,Dict{String,Any}} where outer keys are label values
 """
 function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
-    features=Symbol[],
-    labels=nothing,
-    n_bins=nothing,
-    bin_width=nothing,
-    weighting_norm=nothing,
+    features::Vector{Symbol}=Symbol[],
+    labels::Union{Nothing,Int,Vector{Int}}=nothing,
+    n_bins::Union{Nothing,Int}=nothing,
+    bin_width::Union{Nothing,Float64}=nothing,
+    weighting_norm::Union{Nothing,String}=nothing,
     keep_largest_only::Bool=true,
-    sample_rate=0.03,
+    sample_rate::Float64=0.03,
     get_raw_matrices::Bool=false,
-    slices_2d =nothing,
-    verbose::Bool=false)
+    slices_2d=nothing,
+    verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}}
 
     # Convert parameters to correct types
     bin_width = isnothing(bin_width) ? nothing : Float64(bin_width)
@@ -453,7 +453,7 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     compute_all::Bool=true,
     features::Vector{Symbol}=Symbol[],
     get_raw_matrices::Bool=false,
-    log_buffer::Union{Nothing,Vector{String}}=nothing)
+    log_buffer::Union{Nothing,Vector{String}}=nothing)::Tuple{Dict{String,Any}, Float64}
     
     radiomic_features = Dict{String,Any}()
     total_time_accumulated = 0.0

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -66,7 +66,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     sample_rate::Float64=0.03,
     get_raw_matrices::Bool=false,
     slices_2d=nothing,
-    verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}}
+    verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}, Dict{Tuple{Int,Int},Any}}
 
     # Convert parameters to correct types
     bin_width = isnothing(bin_width) ? nothing : Float64(bin_width)
@@ -740,18 +740,127 @@ end
 # - Precompilation: executed automatically at the first `using Radiomics`.
 # - Reduces the TTFX (Time To First eXecution) for the package users.
 @setup_workload begin
-    # Small synthetic data only to "warm up" the code for precompile
+    # Small synthetic data for precompilation warmup
     img_small  = Float64.(reshape(1:1000, 10, 10, 10))
     mask_small = zeros(Float64, 10, 10, 10)
     mask_small[3:7, 3:7, 3:7] .= 1.0
-    spacing    = [1.0, 1.0, 1.0]
+
+    # Multi-label mask
+    mask_multi = zeros(Float64, 10, 10, 10)
+    mask_multi[2:4, 2:4, 2:4] .= 1.0
+    mask_multi[6:8, 6:8, 6:8] .= 2.0
+
+    spacing = [1.0, 1.0, 1.0]
 
     @compile_workload begin
+        # --- Default bin_width ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            sample_rate = 1.0,
+            sample_rate       = 1.0,
             keep_largest_only = false,
-            verbose  = false
+            verbose           = false
+        )
+
+        # --- n_bins ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            n_bins            = 32,
+            sample_rate       = 1.0,
+            keep_largest_only = false,
+            verbose           = false
+        )
+
+        # --- bin_width explicit ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            bin_width         = 25.0,
+            sample_rate       = 1.0,
+            keep_largest_only = false,
+            verbose           = false
+        )
+
+        # --- Weighting norms ---
+        for wn in ["euclidean", "infinity", "manhattan", "no_weighting"]
+            extract_radiomic_features(
+                img_small, mask_small, spacing;
+                weighting_norm    = wn,
+                sample_rate       = 1.0,
+                keep_largest_only = false,
+                verbose           = false
+            )
+        end
+
+        # --- Selective features ---
+        for feat in [
+            [:glcm],
+            [:first_order],
+            [:shape3d],
+            [:glszm],
+            [:ngtdm],
+            [:glrlm],
+            [:gldm],
+            [:glcm, :first_order],
+            [:glcm, :glszm, :glrlm, :gldm, :ngtdm],
+        ]
+            extract_radiomic_features(
+                img_small, mask_small, spacing;
+                features          = feat,
+                sample_rate       = 1.0,
+                keep_largest_only = false,
+                verbose           = false
+            )
+        end
+
+        # --- keep_largest_only = true ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            sample_rate       = 1.0,
+            keep_largest_only = true,
+            verbose           = false
+        )
+
+        # --- Multi-label ---
+        extract_radiomic_features(
+            img_small, mask_multi, spacing;
+            labels            = [1, 2],
+            sample_rate       = 1.0,
+            keep_largest_only = false,
+            verbose           = false
+        )
+
+        # --- Single explicit label ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            labels            = 1,
+            sample_rate       = 1.0,
+            keep_largest_only = false,
+            verbose           = false
+        )
+
+        # --- get_raw_matrices ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            get_raw_matrices  = true,
+            sample_rate       = 1.0,
+            keep_largest_only = false,
+            verbose           = false
+        )
+
+        # --- 2D slice extraction ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            slices_2d         = [(1, 5)],
+            sample_rate       = 1.0,
+            keep_largest_only = true,
+            verbose           = false
+        )
+
+        # --- Multiple slices ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            slices_2d         = [(1, 5), (2, 5), (3, 5)],
+            keep_largest_only = false,
+            verbose           = false
         )
     end
 end

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -55,126 +55,94 @@ include("diagnostic_features.jl")
     - Multiple labels: Dict{Int,Dict{String,Any}} where outer keys are label values
 """
 function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
-    features::Vector{Symbol}=Symbol[],
-    labels::Union{Nothing,Int,Vector{Int}}=nothing,
-    n_bins::Union{Nothing,Int}=nothing,
-    bin_width::Union{Nothing,Float64}=nothing,
-    weighting_norm::Union{Nothing,String}=nothing,
+    features=Symbol[],
+    labels=nothing,
+    n_bins=nothing,
+    bin_width=nothing,
+    weighting_norm=nothing,
     keep_largest_only::Bool=true,
     get_raw_matrices::Bool=false,
     slices_2d=nothing,
     verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}, Dict{Tuple{Int,Int},Any}}
 
-    # Convert parameters to correct types
-    bin_width = isnothing(bin_width) ? nothing : Float64(bin_width)
-    
-    # Convert features (supports String, Vector{String}, Symbol, Vector{Symbol})
-    if features isa String
-        features = lowercase(features) == "all" ? Symbol[] : [Symbol(lowercase(features))]
-    elseif features isa AbstractVector && !isempty(features) && eltype(features) <: AbstractString
-        features = Symbol[Symbol(lowercase(string(f))) for f in features]
-    elseif features isa AbstractVector && !isempty(features) && !(eltype(features) <: Symbol)
-        # Handle case where features might be a mix or other types
-        features = Symbol[Symbol(lowercase(string(f))) for f in features]
-    end
-    
-    # Convert labels (supports Int, Vector{Int})
-    if labels isa AbstractVector
-        labels = Int[Int(l) for l in labels]
-    elseif !isnothing(labels) && !(labels isa Int)
-        labels = Int(labels)
-    elseif isnothing(labels) # No label given, default is 1
-        labels = Int(1)
-    end
-    
-    # Convert spacing (supports any numeric vector/list)
-    voxel_spacing_input = Float64[Float64(s) for s in voxel_spacing_input]
-    
-    if length(voxel_spacing_input) > 3
-        throw(ArgumentError("voxel_spacing_input is too long! It should have 2 or 3 elements."))
-    elseif length(voxel_spacing_input) < 2
-        throw(ArgumentError("voxel_spacing_input is too short! It should have 2 or 3 elements."))
-    end
-    
-    # Convert n_bins if provided
-    if !isnothing(n_bins)
-        n_bins = Int(n_bins)
-    end
-    
-    # Convert weighting_norm if provided
-    if !isnothing(weighting_norm)
-        weighting_norm = String(weighting_norm)
-    end
+    # Cast all inputs to correct types
+    p = _cast_inputs(
+        img_input,
+        mask_input,
+        voxel_spacing_input,
+        features,
+        labels,
+        n_bins,
+        bin_width,
+        weighting_norm,
+        slices_2d,
+        keep_largest_only,
+        get_raw_matrices,
+        verbose  
+    )
 
-    compute_all = isempty(features) || :all in features
-
-    img_input, mask_input, voxel_spacing_input = prepare_inputs(img_input, mask_input, voxel_spacing_input)
+    compute_all = isempty(p.features) || :all in p.features
 
     # Management slices_2d
-    if !isnothing(slices_2d)
+    if !isnothing(p.slices_2d)
         results_2d = Dict{Tuple{Int,Int}, Any}()
-        dict_lock = ReentrantLock()
+        dict_lock  = ReentrantLock()
 
-        Threads.@threads for i in eachindex(slices_2d)
-            plan, slice_idx = slices_2d[i]
-            
-            if verbose
-                lock(dict_lock) do 
+        Threads.@threads for i in eachindex(p.slices_2d)
+            plan, slice_idx = p.slices_2d[i]
+
+            if p.verbose
+                lock(dict_lock) do
                     println("Extracting 2D slice: Plane=$plan, slice=$slice_idx")
                 end
             end
-            
-            # Use @view to avoid unnecessary memory allocations
+
             img_slice = if plan == 1
-                @view img_input[slice_idx, :, :]
+                @view p.img[slice_idx, :, :]
             elseif plan == 2
-                @view img_input[:, slice_idx, :]
+                @view p.img[:, slice_idx, :]
             elseif plan == 3
-                @view img_input[:, :, slice_idx]
+                @view p.img[:, :, slice_idx]
             else
                 error("Invalid plane: $plan. Must be 1, 2, or 3")
             end
-            
+
             mask_slice = if plan == 1
-                @view mask_input[slice_idx, :, :]
+                @view p.mask[slice_idx, :, :]
             elseif plan == 2
-                @view mask_input[:, slice_idx, :]
+                @view p.mask[:, slice_idx, :]
             elseif plan == 3
-                @view mask_input[:, :, slice_idx]
+                @view p.mask[:, :, slice_idx]
             else
                 error("Invalid plane: $plan. Must be 1, 2, or 3")
             end
-            
-            # 2D spacing calculation
+
             spacing_2d = if plan == 1
-                [voxel_spacing_input[2], voxel_spacing_input[3], voxel_spacing_input[1]]  # y, z, (x)
+                [p.spacing[2], p.spacing[3], p.spacing[1]]
             elseif plan == 2
-                [voxel_spacing_input[1], voxel_spacing_input[3], voxel_spacing_input[2]]  # x, z, (y)
-            elseif plan == 3 
-                [voxel_spacing_input[1], voxel_spacing_input[2], voxel_spacing_input[3]]  # x, y, (z)
+                [p.spacing[1], p.spacing[3], p.spacing[2]]
+            elseif plan == 3
+                [p.spacing[1], p.spacing[2], p.spacing[3]]
             end
-            
-            # Call the main function passing the light views
+
             result = extract_radiomic_features(
                 img_slice, mask_slice, spacing_2d;
-                features=features,
-                labels=labels,
-                n_bins=n_bins,
-                bin_width=bin_width,
-                weighting_norm=weighting_norm,
-                keep_largest_only=keep_largest_only,
-                get_raw_matrices=get_raw_matrices,
-                verbose=verbose
+                features          = p.features,
+                labels            = p.labels,
+                n_bins            = p.n_bins,
+                bin_width         = p.bin_width,
+                weighting_norm    = p.weighting_norm,
+                keep_largest_only = p.keep_largest_only,
+                get_raw_matrices  = p.get_raw_matrices,
+                verbose           = p.verbose
             )
-            
-            # Thread-safe saving
+
             lock(dict_lock) do
                 results_2d[(plan, slice_idx)] = result
             end
         end
 
-        # Final return
-        if length(slices_2d) == 1
+        if length(p.slices_2d) == 1
             key = first(keys(results_2d))
             return results_2d[key]
         else
@@ -183,29 +151,23 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     end
 
     # Handle multi-label processing
-    if labels isa Vector{Int}
-        if verbose
-            println("Processing multiple labels: ", labels)
+    if p.labels isa Vector{Int}
+        if p.verbose
+            println("Processing multiple labels: ", p.labels)
             println("Active threads: ", Threads.nthreads())
         end
-        
-        results = Dict{Int, Dict{String,Any}}()
+
+        results        = Dict{Int, Dict{String,Any}}()
         skipped_labels = Int[]
-        
-        # Create a lock to synchronize access to shared dictionaries
-        results_lock = ReentrantLock()
-        
-        # Parallelize label processing with log buffering
-        tasks = map(labels) do label
+        results_lock   = ReentrantLock()
+
+        tasks = map(p.labels) do label
             Threads.@spawn let label = label
-                # Buffer for logs of this label
                 log_buffer = String[]
-                
+
                 push!(log_buffer, "\n=== Processing LABEL $label ===")
-                
-                # Create binary mask for the current label
-                local mask_to_use, voxel_count = extract_and_check_mask(mask_input, label)
-                # Check if label exists
+
+                local mask_to_use, voxel_count = extract_and_check_mask(p.mask, label)
                 if voxel_count == 0
                     lock(results_lock) do
                         push!(skipped_labels, label)
@@ -216,69 +178,68 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 push!(log_buffer, "Label $label contains $voxel_count voxels")
                 push!(log_buffer, "Applying bounding box to Label $label...")
                 local img_to_use
-                img_to_use, mask_to_use = bounding_box(img_input, mask_to_use, verbose; log_buffer=log_buffer)
-                
+                img_to_use, mask_to_use = bounding_box(p.img, mask_to_use, p.verbose; log_buffer=log_buffer)
+
                 if compute_all
                     push!(log_buffer, "Computing ALL features")
                 else
-                    push!(log_buffer, "Computing selected features: $(join(string.(features), ", "))")
+                    push!(log_buffer, "Computing selected features: $(join(string.(p.features), ", "))")
                 end
-                if !isnothing(n_bins)
-                    push!(log_buffer, "Using n_bins = $n_bins")
+                if !isnothing(p.n_bins)
+                    push!(log_buffer, "Using n_bins = $(p.n_bins)")
                 else
-                    push!(log_buffer, "Using bin_width = $bin_width")
+                    push!(log_buffer, "Using bin_width = $(p.bin_width)")
                 end
-                if keep_largest_only
+                if p.keep_largest_only
                     push!(log_buffer, "keep_largest_only = true (will be applied to selected label)")
                 end
-                
+
                 try
-                    total_start_time = time()
-                    total_time_accumulated = 0.0 
+                    total_start_time       = time()
+                    total_time_accumulated = 0.0
 
-                    # Compute radiomic features passing the log_buffer
                     radiomic_features, time_acc = _compute_radiomics_impl(
-                        img_to_use, mask_to_use, voxel_spacing_input, voxel_count;
-                        n_bins=n_bins,
-                        bin_width=bin_width,
-                        weighting_norm=weighting_norm,
-                        verbose=verbose,
-                        keep_largest_only=keep_largest_only,
-                        compute_all=compute_all,
-                        features=features,
-                        get_raw_matrices=get_raw_matrices,
-                        log_buffer=log_buffer
+                        img_to_use, mask_to_use, p.spacing, voxel_count;
+                        n_bins            = p.n_bins,
+                        bin_width         = p.bin_width,
+                        weighting_norm    = p.weighting_norm,
+                        verbose           = p.verbose,
+                        keep_largest_only = p.keep_largest_only,
+                        compute_all       = compute_all,
+                        features          = p.features,
+                        get_raw_matrices  = p.get_raw_matrices,
+                        log_buffer        = log_buffer
                     )
-                    
-                    total_time_accumulated += time_acc
-                    total_time_real = time() - total_start_time
 
-                    # Add summary to buffer
+                    total_time_accumulated += time_acc
+                    total_time_real         = time() - total_start_time
+
                     push!(log_buffer, "\n--- Label $label Summary ---")
                     push!(log_buffer, "Measured time of single function'sum (sum of @timed): $(total_time_accumulated) sec")
                     push!(log_buffer, "Real time (end-to-end): $(total_time_real) sec")
                     push!(log_buffer, "Overhead: $(total_time_real - total_time_accumulated) sec")
-                    
-                    diagnosis_features = get_diagnosis_features(bin_width, voxel_spacing_input, total_time_real, 
-                                            weighting_norm, n_bins, keep_largest_only,
-                                            img_input, img_to_use, mask_input, mask_to_use)
+
+                    diagnosis_features = get_diagnosis_features(
+                        p.bin_width, p.spacing, total_time_real,
+                        p.weighting_norm, p.n_bins, p.keep_largest_only,
+                        p.img, img_to_use, p.mask, mask_to_use
+                    )
                     merge!(radiomic_features, diagnosis_features)
-                    
-                    # Print diagnosis features to buffer
+
                     print_features_diagnosis("Diagnosis Features", diagnosis_features; log_buffer=log_buffer)
-                    
+
                     push!(log_buffer, "Total features extracted: $(length(radiomic_features))")
                     push!(log_buffer, "Features extraction completed for LABEL $label")
 
-                    # Add label identifier
                     radiomic_features["label_id"] = label
-                    
+
                     return (label, radiomic_features, log_buffer)
-                    
+
                 catch e
                     error_msg = "Error processing label $label: $e"
                     push!(log_buffer, error_msg)
                     @warn error_msg
+                    @warn sprint(showerror, e, catch_backtrace())
                     lock(results_lock) do
                         push!(skipped_labels, label)
                     end
@@ -286,119 +247,107 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 end
             end
         end
-        
-        # Collect results from tasks and print in order
+
         for task in tasks
             result = fetch(task)
             if !isnothing(result)
                 label, features_dict, logs = result
-                
-                # Print logs in order
-                if verbose
+
+                if p.verbose
                     for line in logs
                         println(line)
                     end
                 end
-                
-                # Save results if processing was successful
+
                 if !isnothing(features_dict)
                     results[label] = features_dict
                 end
             end
         end
-        
-        if verbose
+
+        if p.verbose
             println("\n======================")
             println("Multi-label processing completed")
-            println("Labels requested: ", labels)
+            println("Labels requested: ", p.labels)
             println("Labels successfully processed: ", sort(collect(keys(results))))
             if !isempty(skipped_labels)
                 println("Labels skipped (not found or error): ", sort(skipped_labels))
             end
             println("======================")
         end
-        
+
         return results
     end
 
-    # Single label or default processing
-    if labels isa Int # Explicit single label specified by user or the default value (1)
-        label = labels
-        if verbose
-            println("Extracting LABEL $labels")
-        end
-    end
-        
-    mask_to_use, voxel_count = extract_and_check_mask(mask_input, label)
+    mask_to_use, voxel_count = extract_and_check_mask(p.mask, p.labels)
     if voxel_count == 0
-        error("Label $label not found in mask (no voxels with this value)")
-    end
-        
-    if verbose
-        println("Label $label contains $voxel_count voxels")
+        error("Label $(p.labels) not found in mask (no voxels with this value)")
     end
 
-    img_to_use, mask_to_use = bounding_box(img_input, mask_to_use, verbose)
-        
-    total_start_time = time()
-    total_time_accumulated = 0.0 
+    if p.verbose
+        println("Label $(p.labels) contains $voxel_count voxels")
+    end
 
-    if verbose
+    img_to_use, mask_to_use = bounding_box(p.img, mask_to_use, p.verbose)
+
+    total_start_time       = time()
+    total_time_accumulated = 0.0
+
+    if p.verbose
         println("Active threads: ", Threads.nthreads())
         println("Extracting radiomic features...")
-        println("Processing LABEL: $label")
+        println("Processing LABEL: $(p.labels)")
         if compute_all
             println("Computing ALL features")
         else
-            println("Computing selected features: ", join(string.(features), ", "))
+            println("Computing selected features: ", join(string.(p.features), ", "))
         end
-        if !isnothing(n_bins)
-            println("Using n_bins = $n_bins")
-        elseif !isnothing(bin_width)
-            println("Using bin_width = $bin_width")
+        if !isnothing(p.n_bins)
+            println("Using n_bins = $(p.n_bins)")
+        elseif !isnothing(p.bin_width)
+            println("Using bin_width = $(p.bin_width)")
         else
             println("Using default bin width: 25.0")
         end
-        if keep_largest_only
+        if p.keep_largest_only
             println("keep_largest_only = true (will be applied to selected label)")
         end
     end
 
-    # Compute radiomic features using the internal implementation
-    # Do NOT pass log_buffer here (uses default =nothing for direct printing)
     radiomic_features, time_acc = _compute_radiomics_impl(
-        img_to_use, mask_to_use, voxel_spacing_input, voxel_count;
-        n_bins=n_bins,
-        bin_width=bin_width,
-        weighting_norm=weighting_norm,
-        verbose=verbose,
-        keep_largest_only=keep_largest_only,
-        compute_all=compute_all,
-        features=features,
-        get_raw_matrices=get_raw_matrices
+        img_to_use, mask_to_use, p.spacing, voxel_count;
+        n_bins            = p.n_bins,
+        bin_width         = p.bin_width,
+        weighting_norm    = p.weighting_norm,
+        verbose           = p.verbose,
+        keep_largest_only = p.keep_largest_only,
+        compute_all       = compute_all,
+        features          = p.features,
+        get_raw_matrices  = p.get_raw_matrices
     )
-    
-    total_time_accumulated += time_acc
-    total_time_real = time() - total_start_time
 
-    if verbose
+    total_time_accumulated += time_acc
+    total_time_real         = time() - total_start_time
+
+    if p.verbose
         println("\n======================")
         println("Measured time of single function'sum (sum of @timed): $(total_time_accumulated) sec")
         println("Real time (end-to-end): $(total_time_real) sec")
         println("Overhead: $(total_time_real - total_time_accumulated) sec")
-        diagnosis_features = get_diagnosis_features(bin_width, voxel_spacing_input, total_time_real, 
-                                                    weighting_norm, n_bins, keep_largest_only,
-                                                    img_input, img_to_use, mask_input, mask_to_use)
+        diagnosis_features = get_diagnosis_features(
+            p.bin_width, p.spacing, total_time_real,
+            p.weighting_norm, p.n_bins, p.keep_largest_only,
+            p.img, img_to_use, p.mask, mask_to_use
+        )
         merge!(radiomic_features, diagnosis_features)
         print_features_diagnosis("Diagnosis Features", diagnosis_features)
         println("---------------------")
         println("Total features extracted: $(length(radiomic_features))")
-        println("Features extraction completed for LABEL $label")
+        println("Features extraction completed for LABEL $(p.labels)")
         println("======================")
     end
 
-    # Add label identifier
-    radiomic_features["label_id"] = label
+    radiomic_features["label_id"] = p.labels
 
     return radiomic_features
 end
@@ -451,9 +400,6 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
             push!(log_buffer, msg)
         end
     end
-    
-    # Sanity check
-    input_sanity_check(img, mask, verbose)
 
     # Validate binning parameters
     if isnothing(n_bins) && !isnothing(bin_width) && voxel_count > 0
@@ -729,6 +675,17 @@ end
     mask_small = zeros(Float64, 10, 10, 10)
     mask_small[3:7, 3:7, 3:7] .= 1.0
 
+    # Small 2D synthetic data for precompilation warmup
+    img_small_2d  = Float64.(reshape(1:100, 10, 10))
+    mask_small_2d = zeros(Float64, 10, 10)
+    mask_small_2d[3:7, 3:7] .= 1.0
+
+    # 2D mask multi-label
+    img_small_2d_multi = Float64.(reshape(1:100, 10, 10))
+    mask_small_2d_multi = zeros(Float64, 10, 10)
+    mask_small_2d_multi[3:7, 3:7] .= 1.0
+    mask_small_2d_multi[6:8, 6:8] .= 2.0
+    
     # Multi-label mask
     mask_multi = zeros(Float64, 10, 10, 10)
     mask_multi[2:4, 2:4, 2:4] .= 1.0
@@ -736,7 +693,29 @@ end
 
     spacing = [1.0, 1.0, 1.0]
 
-    @compile_workload begin
+    @compile_workload begin        
+        # 2D
+        extract_radiomic_features(
+            img_small_2d, mask_small_2d, spacing;
+            keep_largest_only = true,
+            verbose           = false
+        )
+
+        # 2D mask multi-label
+        extract_radiomic_features(
+            img_small_2d_multi, mask_small_2d_multi, spacing;
+            keep_largest_only = false,
+            verbose           = false
+        )
+
+        #2D label
+        extract_radiomic_features(
+            img_small_2d_multi, mask_small_2d_multi, spacing;
+            keep_largest_only = false,
+            labels            = [1,2],
+            verbose           = false
+        )
+        
         # --- Default bin_width ---
         extract_radiomic_features(
             img_small, mask_small, spacing;

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -444,16 +444,16 @@ end
     - Tuple of (radiomic_features::Dict, total_time_accumulated::Float64)
 """
 function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
-    n_bins=nothing,
-    bin_width=nothing,
-    weighting_norm=nothing,
+    n_bins::Union{Nothing,Int}=nothing,
+    bin_width::Union{Nothing,Float64}=nothing,
+    weighting_norm::Union{Nothing,String}=nothing,
     verbose::Bool=false,
-    sample_rate=0.03,
+    sample_rate::Float64=0.03,
     keep_largest_only::Bool=true,
     compute_all::Bool=true,
-    features=Symbol[],
+    features::Vector{Symbol}=Symbol[],
     get_raw_matrices::Bool=false,
-    log_buffer=nothing)
+    log_buffer::Union{Nothing,Vector{String}}=nothing)
     
     radiomic_features = Dict{String,Any}()
     total_time_accumulated = 0.0
@@ -476,174 +476,192 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     end
 
     # GLCM features
-    if compute_all || :glcm in features 
-        t_glcm_features = Threads.@spawn @timed get_glcm_features(
-            img, mask, voxel_spacing;
-            n_bins=n_bins,
-            bin_width=bin_width,
-            weighting_norm=weighting_norm,
-            get_raw_matrices=get_raw_matrices,
-            verbose=verbose
-        )
+    if compute_all || :glcm in features
+        t_glcm_features = Threads.@spawn begin
+            result = @timed get_glcm_features(
+                img, mask, voxel_spacing;
+                n_bins=n_bins,
+                bin_width=bin_width,
+                weighting_norm=weighting_norm,
+                get_raw_matrices=get_raw_matrices,
+                verbose=verbose
+            )
+            (result.value, result.time)
+        end
     end
         
     # First order features
     if compute_all || :first_order in features
-        t_first_order_features = Threads.@spawn @timed get_first_order_features(
-            img, mask, voxel_spacing; 
-            n_bins=n_bins, 
-            bin_width=bin_width, 
-            verbose=verbose
-        )
+        t_first_order_features = Threads.@spawn begin
+            result = @timed get_first_order_features(
+                img, mask, voxel_spacing;
+                n_bins=n_bins,
+                bin_width=bin_width,
+                verbose=verbose
+            )
+            (result.value, result.time)
+        end
     end
 
     # GLSZM features
     if compute_all || :glszm in features
-        t_glszm_features = Threads.@spawn @timed get_glszm_features(
-            img, mask, voxel_spacing;
-            n_bins=n_bins,
-            bin_width=bin_width,
-            get_raw_matrices=get_raw_matrices,
-            verbose=verbose
-        )
+        t_glszm_features = Threads.@spawn begin
+            result = @timed get_glszm_features(
+                img, mask, voxel_spacing;
+                n_bins=n_bins,
+                bin_width=bin_width,
+                get_raw_matrices=get_raw_matrices,
+                verbose=verbose
+            )
+            (result.value, result.time)
+        end
     end
 
     # NGTDM features
     if compute_all || :ngtdm in features
-        t_ngtdm_features = Threads.@spawn @timed get_ngtdm_features(
-            img, mask, voxel_spacing;
-            n_bins=n_bins,
-            bin_width=bin_width,
-            get_raw_matrices=get_raw_matrices,
-            verbose=verbose
-        )
+        t_ngtdm_features = Threads.@spawn begin
+            result = @timed get_ngtdm_features(
+                img, mask, voxel_spacing;
+                n_bins=n_bins,
+                bin_width=bin_width,
+                get_raw_matrices=get_raw_matrices,
+                verbose=verbose
+            )
+            (result.value, result.time)
+        end
     end
 
     # GLRLM features
     if compute_all || :glrlm in features
-        t_glrlm_features = Threads.@spawn @timed get_glrlm_features(
-            img, mask, voxel_spacing;
-            n_bins=n_bins,
-            bin_width=bin_width,
-            weighting_norm=weighting_norm,
-            get_raw_matrices=get_raw_matrices,
-            verbose=verbose
-        )
+        t_glrlm_features = Threads.@spawn begin
+            result = @timed get_glrlm_features(
+                img, mask, voxel_spacing;
+                n_bins=n_bins,
+                bin_width=bin_width,
+                weighting_norm=weighting_norm,
+                get_raw_matrices=get_raw_matrices,
+                verbose=verbose
+            )
+            (result.value, result.time)
+        end
     end
 
     # GLDM features
     if compute_all || :gldm in features
-        t_gldm_features = Threads.@spawn @timed get_gldm_features(
-            img, mask, voxel_spacing;
-            n_bins=n_bins,
-            bin_width=bin_width,
-            get_raw_matrices=get_raw_matrices,
-            verbose=verbose
-        )
+        t_gldm_features = Threads.@spawn begin
+            result = @timed get_gldm_features(
+                img, mask, voxel_spacing;
+                n_bins=n_bins,
+                bin_width=bin_width,
+                get_raw_matrices=get_raw_matrices,
+                verbose=verbose
+            )
+            (result.value, result.time)
+        end
     end
 
     # Control dimension of the mask 
     if ndims(mask) == 3
         # 3D shape features
-        if compute_all || :shape3d in features 
-            t_shape3d_features = Threads.@spawn @timed get_shape3d_features(
-                mask, voxel_spacing; 
-                verbose=verbose, 
-                sample_rate=sample_rate, 
-                keep_largest_only=keep_largest_only
-            )
+        if compute_all || :shape3d in features
+            t_shape3d_features = Threads.@spawn begin
+                result = @timed get_shape3d_features(
+                    mask, voxel_spacing;
+                    verbose=verbose,
+                    sample_rate=sample_rate,
+                    keep_largest_only=keep_largest_only
+                )
+                (result.value, result.time)
+            end
         end
     end
 
     # Launch parallel threads for 2D features
     if ndims(mask) == 2
         if compute_all || :shape2d in features
-            t_shape2d_features = Threads.@spawn @timed get_shape2d_features(
-                mask, voxel_spacing;
-                verbose = verbose,
-                keep_largest_only=keep_largest_only
-            )
+            t_shape2d_features = Threads.@spawn begin
+                result = @timed get_shape2d_features(
+                    mask, voxel_spacing;
+                    verbose=verbose,
+                    keep_largest_only=keep_largest_only
+                )
+                (result.value, result.time)
+            end
         end
     end
 
     # First Order features
     if compute_all || :first_order in features
-        results_first_order = fetch(t_first_order_features)
-        first_order_features = results_first_order.value
-        merge!(radiomic_features, first_order_features)
-        total_time_accumulated += results_first_order.time
+        first_order_dict, first_order_time = fetch(t_first_order_features)::Tuple{Dict{String,Any}, Float64}
+        merge!(radiomic_features, first_order_dict)
+        total_time_accumulated += first_order_time
         if verbose
-            log_println("First order: $(results_first_order.time) sec")
-            print_features("First Order Features", first_order_features; log_buffer=log_buffer)
+            log_println("First order: $(first_order_time) sec")
+            print_features("First Order Features", first_order_dict; log_buffer=log_buffer)
         end
     end
 
     # GLCM features
     if compute_all || :glcm in features
-        results_glcm = fetch(t_glcm_features)
-        glcm_features = results_glcm.value
-        merge!(radiomic_features, glcm_features)
-        total_time_accumulated += results_glcm.time
+        glcm_dict, glcm_time = fetch(t_glcm_features)::Tuple{Dict{String,Any}, Float64}
+        merge!(radiomic_features, glcm_dict)
+        total_time_accumulated += glcm_time
         if verbose
-            log_println("GLCM: $(results_glcm.time) sec")
+            log_println("GLCM: $(glcm_time) sec")
             if !get_raw_matrices
-                print_features("GLCM Features", glcm_features; log_buffer=log_buffer)
+                print_features("GLCM Features", glcm_dict; log_buffer=log_buffer)
             end
         end
     end
         
     # GLSZM features
     if compute_all || :glszm in features
-        results_glszm = fetch(t_glszm_features)
-        glszm_features = results_glszm.value
-        merge!(radiomic_features, glszm_features)
-        total_time_accumulated += results_glszm.time
+        glszm_dict, glszm_time = fetch(t_glszm_features)::Tuple{Dict{String,Any}, Float64}
+        merge!(radiomic_features, glszm_dict)
+        total_time_accumulated += glszm_time
         if verbose
-            log_println("GLSZM: $(results_glszm.time) sec")
+            log_println("GLSZM: $(glszm_time) sec")
             if !get_raw_matrices
-                print_features("GLSZM Features", glszm_features; log_buffer=log_buffer)
+                print_features("GLSZM Features", glszm_dict; log_buffer=log_buffer)
             end
         end
     end
 
     # NGTDM features
     if compute_all || :ngtdm in features
-        results_ngtdm = fetch(t_ngtdm_features)
-        ngtdm_features = results_ngtdm.value
-        merge!(radiomic_features, ngtdm_features)
-        total_time_accumulated += results_ngtdm.time
+        ngtdm_dict, ngtdm_time = fetch(t_ngtdm_features)::Tuple{Dict{String,Any}, Float64}
+        merge!(radiomic_features, ngtdm_dict)
+        total_time_accumulated += ngtdm_time
         if verbose
-            log_println("NGTDM: $(results_ngtdm.time) sec")
+            log_println("NGTDM: $(ngtdm_time) sec")
             if !get_raw_matrices
-                print_features("NGTDM Features", ngtdm_features; log_buffer=log_buffer)
+                print_features("NGTDM Features", ngtdm_dict; log_buffer=log_buffer)
             end
         end
     end
 
     # GLRLM features
     if compute_all || :glrlm in features
-        results_glrlm = fetch(t_glrlm_features)
-        glrlm_features = results_glrlm.value
-        merge!(radiomic_features, glrlm_features)
-        total_time_accumulated += results_glrlm.time
+        glrlm_dict, glrlm_time = fetch(t_glrlm_features)::Tuple{Dict{String,Any}, Float64}
+        merge!(radiomic_features, glrlm_dict)
+        total_time_accumulated += glrlm_time
         if verbose
-            log_println("GLRLM: $(results_glrlm.time) sec")
+            log_println("GLRLM: $(glrlm_time) sec")
             if !get_raw_matrices
-                print_features("GLRLM Features", glrlm_features; log_buffer=log_buffer)
+                print_features("GLRLM Features", glrlm_dict; log_buffer=log_buffer)
             end
         end
     end
 
     # GLDM features
     if compute_all || :gldm in features
-        results_gldm = fetch(t_gldm_features)
-        gldm_features = results_gldm.value
-        merge!(radiomic_features, gldm_features)
-        total_time_accumulated += results_gldm.time
+        gldm_dict, gldm_time = fetch(t_gldm_features)::Tuple{Dict{String,Any}, Float64}
+        merge!(radiomic_features, gldm_dict)
+        total_time_accumulated += gldm_time
         if verbose
-            log_println("GLDM: $(results_gldm.time) sec")
+            log_println("GLDM: $(gldm_time) sec")
             if !get_raw_matrices
-                print_features("GLDM Features", gldm_features; log_buffer=log_buffer)
+                print_features("GLDM Features", gldm_dict; log_buffer=log_buffer)
             end
         end
     end
@@ -651,13 +669,12 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     # 3D shape features
     if ndims(mask) == 3
         if compute_all || :shape3d in features
-            results_shape3d = fetch(t_shape3d_features)
-            shape_3d_features = results_shape3d.value
-            merge!(radiomic_features, shape_3d_features)
-            total_time_accumulated += results_shape3d.time
+            shape3d_dict, shape3d_time = fetch(t_shape3d_features)::Tuple{Dict{String,Any}, Float64}
+            merge!(radiomic_features, shape3d_dict)
+            total_time_accumulated += shape3d_time
             if verbose
-                log_println("3D shape: $(results_shape3d.time) sec")
-                print_features("3D Shape Features", shape_3d_features; log_buffer=log_buffer)
+                log_println("3D shape: $(shape3d_time) sec")
+                print_features("3D Shape Features", shape3d_dict; log_buffer=log_buffer)
             end
         end
     end
@@ -665,13 +682,12 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     # 2D shape features
     if ndims(mask) == 2
         if compute_all || :shape2d in features
-            results_shape2d = fetch(t_shape2d_features)
-            shape_2d_features = results_shape2d.value
-            merge!(radiomic_features, shape_2d_features)
-            total_time_accumulated += results_shape2d.time
+            shape2d_dict, shape2d_time = fetch(t_shape2d_features)::Tuple{Dict{String,Any}, Float64}
+            merge!(radiomic_features, shape2d_dict)
+            total_time_accumulated += shape2d_time
             if verbose
-                log_println("2D shape: $(results_shape2d.time) sec")
-                print_features("2D Shape Features", shape_2d_features; log_buffer=log_buffer)
+                log_println("2D shape: $(shape2d_time) sec")
+                print_features("2D Shape Features", shape2d_dict; log_buffer=log_buffer)
             end
         end
     end

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -1,6 +1,9 @@
-using Base.Threads
-
 module Radiomics
+
+using Base.Threads
+using PrecompileTools
+using JSON3
+using TOML
 
 include("utils/utils.jl")
 include("glcm_features.jl")
@@ -12,9 +15,6 @@ include("ngtdm_features.jl")
 include("glrlm_features.jl")
 include("gldm_features.jl")
 include("diagnostic_features.jl")
-
-using JSON3
-using TOML
 
 """
     extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
@@ -717,6 +717,26 @@ Base.@ccallable function c_extract_radiomic_features(
         err_msg = "{\"error\": \"$e\"}\0"
         LAST_JSON_RESULT[] = err_msg
         return pointer(LAST_JSON_RESULT[])
+    end
+end
+
+# @setup_workload for precompile and warm up the code.
+# - Precompilation: executed automatically at the first `using Radiomics`.
+# - Reduces the TTFX (Time To First eXecution) for the package users.
+@setup_workload begin
+    # Small synthetic data only to "warm up" the code for precompile
+    img_small  = Float64.(reshape(1:1000, 10, 10, 10))
+    mask_small = zeros(Float64, 10, 10, 10)
+    mask_small[3:7, 3:7, 3:7] .= 1.0
+    spacing    = [1.0, 1.0, 1.0]
+
+    @compile_workload begin
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            sample_rate = 1.0,
+            keep_largest_only = false,
+            verbose  = false
+        )
     end
 end
 

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -47,7 +47,7 @@ using TOML
     - `keep_largest_only`: If true, keeps only the largest connected component for 3D shape features (default: true).
     - `sample_rate`: The sample rate for feature extraction (optional).
     - `get_raw_matrices`: If true, computes raw (unnormalized, unweighted) GLCM matrices along all directions
-                           and stores them in the result as `"get_raw_matrices"` (Vector of Matrix{Float32}).
+                           and stores them in the result as `"get_raw_matrices"` (Vector of Matrix{Float64}).
     - `slices_2d`: If present, calcule all features on 2d slice - mask, when this parameter is used you can pass 
                             a vector of tuples (plan, slice_idx) where plan is the plane number (1, 2, or 3) and slice_idx is the slice index. 
     - `verbose`: If true, prints progress messages.
@@ -462,13 +462,13 @@ function _compute_radiomics_impl(img, mask, voxel_spacing, voxel_count::Int;
     # Sanity check
     input_sanity_check(img, mask, verbose)
 
+    # Cast and prepare inputs
+    img, mask, voxel_spacing = prepare_inputs(img, mask, voxel_spacing)
+
     # Validate binning parameters
     if isnothing(n_bins) && !isnothing(bin_width) && voxel_count > 0
         validate_binning_parameters(img, mask, bin_width)
     end
-
-    # Cast and prepare inputs
-    img, mask, voxel_spacing = prepare_inputs(img, mask, voxel_spacing)
 
     # GLCM features
     if compute_all || :glcm in features 
@@ -681,9 +681,9 @@ end
 const LAST_JSON_RESULT = Ref{String}("")
 
 Base.@ccallable function c_extract_radiomic_features(
-    img_ptr::Ptr{Float32},
+    img_ptr::Ptr{Float64},
     img_size_x::Int64, img_size_y::Int64, img_size_z::Int64,
-    mask_ptr::Ptr{Float32},
+    mask_ptr::Ptr{Float64},
     spacing_x::Float64, spacing_y::Float64, spacing_z::Float64,
     binWidth::Float64
 )::Cstring

--- a/src/diagnostic_features.jl
+++ b/src/diagnostic_features.jl
@@ -1,5 +1,14 @@
-function get_diagnosis_features(sample_rate, bin_width, voxel_spacing, total_time_real, 
-                                weighting_norm, n_bins, keep_largest_only, image_input, img_to_use, mask_input, mask_to_use)
+function get_diagnosis_features(sample_rate::Float64,
+                                 bin_width::Union{Float64,Nothing},
+                                 voxel_spacing::Vector{Float64},
+                                 total_time_real::Float64,
+                                 weighting_norm::Union{String,Nothing},
+                                 n_bins::Union{Int,Nothing},
+                                 keep_largest_only::Bool,
+                                 image_input::AbstractArray,
+                                 img_to_use::AbstractArray,
+                                 mask_input::AbstractArray,
+                                 mask_to_use::AbstractArray)::Dict{String,Any}
 
     diagnosis_features = Dict{String, Any}()
 
@@ -40,7 +49,9 @@ function get_diagnosis_features(sample_rate, bin_width, voxel_spacing, total_tim
     return diagnosis_features
 end
     
-function print_features_diagnosis(title::String, features::Dict{String, Any}; log_buffer::Union{Vector{String}, Nothing}=nothing)
+function print_features_diagnosis(title::String,
+                                   features::Dict{String,Any};
+                                   log_buffer::Union{Vector{String},Nothing}=nothing)::Nothing
     output = String[]
     
     push!(output, "\n--- $title ---")
@@ -59,4 +70,7 @@ function print_features_diagnosis(title::String, features::Dict{String, Any}; lo
         
         append!(log_buffer, output)
     end
+
+    return nothing
+    
 end

--- a/src/diagnostic_features.jl
+++ b/src/diagnostic_features.jl
@@ -1,3 +1,39 @@
+using TOML
+
+# Create a static cache for versions, read from disk ONLY ONCE across the lifetime of the module
+const RADIOMICS_VERSION_CACHE = Ref{Union{Nothing, Tuple{String, String}}}(nothing)
+
+"""
+    _get_cached_versions()
+
+Helper function to parse the Project.toml file on the first call and cache the results.
+Subsequent calls bypass disk I/O entirely.
+"""
+function _get_cached_versions()
+    if isnothing(RADIOMICS_VERSION_CACHE[])
+        project_file = joinpath(dirname(dirname(@__FILE__)), "Project.toml")
+        if isfile(project_file)
+            try
+                project_data = TOML.parsefile(project_file) 
+                ver = get(project_data, "version", "unknown")
+                j_ver = get(get(project_data, "compat", Dict()), "julia", "unknown")
+                RADIOMICS_VERSION_CACHE[] = (string(ver), string(j_ver))
+            catch
+                RADIOMICS_VERSION_CACHE[] = ("unknown", "unknown")
+            end
+        else
+            RADIOMICS_VERSION_CACHE[] = ("unknown", "unknown")
+        end
+    end
+    return RADIOMICS_VERSION_CACHE[]
+end
+
+"""
+    get_diagnosis_features(...)
+
+Collects execution metadata, system properties, and image metrics.
+Optimized to use a static version cache and eliminate redundant logic checks on primitive types.
+"""
 function get_diagnosis_features(sample_rate::Float64,
                                  bin_width::Union{Float64,Nothing},
                                  voxel_spacing::Vector{Float64},
@@ -12,29 +48,21 @@ function get_diagnosis_features(sample_rate::Float64,
 
     diagnosis_features = Dict{String, Any}()
 
-    # Read version from Project.toml
-    project_file = joinpath(dirname(dirname(@__FILE__)), "Project.toml")
-    if isfile(project_file)
-        project_data = TOML.parsefile(project_file) 
-        version = get(project_data, "version", "unknown")
-        julia_version = get(get(project_data, "compat", Dict()), "julia", "unknown")
-    else
-        version = "unknown"
-        julia_version = "unknown"
-    end
+    # Retrieve version metrics from cache (zero disk I/O if previously parsed)
+    version, julia_version = _get_cached_versions()
 
-    #parameters of the software
+    # Parameters of the software
     diagnosis_features["diagnosis_Version_of_Radiomicsjl"] = version
     diagnosis_features["diagnosis_Version_of_Julia"] = julia_version
     
-    #parameters of the image processing
-    diagnosis_features["diagnosis_Sample_rate"] = !isnothing(sample_rate) ? sample_rate : 0.03
-    diagnosis_features["diagnosis_Bin_width"] = !isnothing(bin_width) ? bin_width : 25.0
-    diagnosis_features["diagnosis_Number_of_bins"] = !isnothing(n_bins) ? n_bins : 32
-    diagnosis_features["diagnosis_Weighting_norm"] = !isnothing(weighting_norm) ? weighting_norm : "no_weighting"
-    diagnosis_features["diagnosis_Keep_largest_only"] = !isnothing(keep_largest_only) ? keep_largest_only : true
+    # Parameters of the image processing (Removed redundant isnothing checks on non-nullable primitive types)
+    diagnosis_features["diagnosis_Sample_rate"] = sample_rate
+    diagnosis_features["diagnosis_Bin_width"] = isnothing(bin_width) ? 25.0 : bin_width
+    diagnosis_features["diagnosis_Number_of_bins"] = isnothing(n_bins) ? 32 : n_bins
+    diagnosis_features["diagnosis_Weighting_norm"] = isnothing(weighting_norm) ? "no_weighting" : weighting_norm
+    diagnosis_features["diagnosis_Keep_largest_only"] = keep_largest_only
     
-    #parameters of the image
+    # Parameters of the image
     diagnosis_features["diagnosis_Voxel_spacing"] = collect(voxel_spacing)
     diagnosis_features["diagnosis_Image_size"] = collect(size(image_input))
     diagnosis_features["diagnosis_Image_size_cropped"] = collect(size(img_to_use))
@@ -42,35 +70,42 @@ function get_diagnosis_features(sample_rate::Float64,
     diagnosis_features["diagnosis_Mask_size_cropped"] = collect(size(mask_to_use))
     diagnosis_features["diagnosis_Dimensionality_of_image"] = string(ndims(image_input)) * "D"
     
-    #parameters of the system
+    # Parameters of the system
     diagnosis_features["diagnosis_Number_of_threads"] = Threads.nthreads()
     diagnosis_features["diagnosis_Total_time_real"] = total_time_real
 
     return diagnosis_features
 end
-    
+
+"""
+    print_features_diagnosis(title, features; log_buffer=nothing)
+
+Prints or logs metadata features. Optimized to run allocation-free by avoiding 
+temporary intermediate string array allocations.
+"""
 function print_features_diagnosis(title::String,
                                    features::Dict{String,Any};
                                    log_buffer::Union{Vector{String},Nothing}=nothing)::Nothing
-    output = String[]
     
-    push!(output, "\n--- $title ---")
-    sorted_keys = sort(collect(keys(features)))
-    for (i, k) in enumerate(sorted_keys)
-        push!(output, "  $i. $(rpad(k, 35)) => $(features[k])")
-    end
-    push!(output, "Subtotal: $(length(features)) features")
+    # Minimize memory footprint by collecting and sorting only the dictionary keys
+    sorted_keys = sort!(collect(keys(features)))
+    num_features = length(features)
     
     if isnothing(log_buffer)
-        
-        for line in output
-            println(line)
+        # Direct streaming to STDOUT, bypassing intermediate buffer array generation
+        println("\n--- $title ---")
+        for (i, k) in enumerate(sorted_keys)
+            println("  $i. $(rpad(k, 35)) => $(features[k])")
         end
+        println("Subtotal: $num_features features")
     else
-        
-        append!(log_buffer, output)
+        # Direct push into the existing shared log stream to lower Garbage Collector pressure
+        push!(log_buffer, "\n--- $title ---")
+        for (i, k) in enumerate(sorted_keys)
+            push!(log_buffer, "  $i. $(rpad(k, 35)) => $(features[k])")
+        end
+        push!(log_buffer, "Subtotal: $num_features features")
     end
 
     return nothing
-    
 end

--- a/src/diagnostic_features.jl
+++ b/src/diagnostic_features.jl
@@ -1,5 +1,5 @@
 function get_diagnosis_features(sample_rate, bin_width, voxel_spacing, total_time_real, 
-                                weighting_norm, n_bins, keep_largest_only, image, mask)
+                                weighting_norm, n_bins, keep_largest_only, image_input, img_to_use, mask_input, mask_to_use)
 
     diagnosis_features = Dict{String, Any}()
 
@@ -27,9 +27,11 @@ function get_diagnosis_features(sample_rate, bin_width, voxel_spacing, total_tim
     
     #parameters of the image
     diagnosis_features["diagnosis_Voxel_spacing"] = collect(voxel_spacing)
-    diagnosis_features["diagnosis_Image_size"] = collect(size(image))
-    diagnosis_features["diagnosis_Mask_size"] = collect(size(mask))
-    diagnosis_features["diagnosis_Dimensionality_of_image"] = string(ndims(image)) * "D"
+    diagnosis_features["diagnosis_Image_size"] = collect(size(image_input))
+    diagnosis_features["diagnosis_Image_size_cropped"] = collect(size(img_to_use))
+    diagnosis_features["diagnosis_Mask_size"] = collect(size(mask_input))
+    diagnosis_features["diagnosis_Mask_size_cropped"] = collect(size(mask_to_use))
+    diagnosis_features["diagnosis_Dimensionality_of_image"] = string(ndims(image_input)) * "D"
     
     #parameters of the system
     diagnosis_features["diagnosis_Number_of_threads"] = Threads.nthreads()

--- a/src/diagnostic_features.jl
+++ b/src/diagnostic_features.jl
@@ -34,8 +34,7 @@ end
 Collects execution metadata, system properties, and image metrics.
 Optimized to use a static version cache and eliminate redundant logic checks on primitive types.
 """
-function get_diagnosis_features(sample_rate::Float64,
-                                 bin_width::Union{Float64,Nothing},
+function get_diagnosis_features(bin_width::Union{Float64,Nothing},
                                  voxel_spacing::Vector{Float64},
                                  total_time_real::Float64,
                                  weighting_norm::Union{String,Nothing},
@@ -56,7 +55,6 @@ function get_diagnosis_features(sample_rate::Float64,
     diagnosis_features["diagnosis_Version_of_Julia"] = julia_version
     
     # Parameters of the image processing (Removed redundant isnothing checks on non-nullable primitive types)
-    diagnosis_features["diagnosis_Sample_rate"] = sample_rate
     diagnosis_features["diagnosis_Bin_width"] = isnothing(bin_width) ? 25.0 : bin_width
     diagnosis_features["diagnosis_Number_of_bins"] = isnothing(n_bins) ? 32 : n_bins
     diagnosis_features["diagnosis_Weighting_norm"] = isnothing(weighting_norm) ? "no_weighting" : weighting_norm

--- a/src/first_order_features.jl
+++ b/src/first_order_features.jl
@@ -17,64 +17,71 @@ function get_first_order_features(img::AbstractArray{Float64},
                                    n_bins::Union{Int,Nothing}=nothing,
                                    bin_width::Union{Float64,Nothing}=nothing,
                                    verbose::Bool=false)::Dict{String,Any}
-    if verbose
-        println("Extracting first order features...")
+
+    verbose && println("Extracting first order features...")
+
+    roi_voxels = img[mask]
+    any(isnan, roi_voxels) && error("Image contains NaN values")
+    n = length(roi_voxels)
+
+    voxel_volume = prod(voxel_spacing)
+
+    sorted_voxels = sort(roi_voxels)
+    vmin = sorted_voxels[1]
+    vmax = sorted_voxels[end]
+
+    function _percentile(sv::Vector{Float64}, p::Float64)
+        idx = clamp(round(Int, p / 100.0 * length(sv)), 1, length(sv))
+        return sv[idx]
     end
 
-    roi_voxels = Float64.(img[mask])
-    any(isnan, roi_voxels) && error("Image contains NaN values")
-    
-    voxel_volume::Float64 = prod(Float64.(voxel_spacing)) 
+    p10 = _percentile(sorted_voxels, 10.0)
+    p25 = _percentile(sorted_voxels, 25.0)
+    p50 = _percentile(sorted_voxels, 50.0)
+    p75 = _percentile(sorted_voxels, 75.0)
+    p90 = _percentile(sorted_voxels, 90.0)
+
+    mean_val = sum(roi_voxels) / n
+
+    disc, n_bins_actual, gray_levels, bin_width_used = discretize_image(
+        img, mask;
+        n_bins=n_bins,
+        bin_width=bin_width,
+        vmin=vmin,
+        vmax=vmax
+    )
+    discretized_roi_voxels = disc[mask]
+    p_probs = get_voxel_probabilities(discretized_roi_voxels)
 
     first_order_features = Dict{String,Any}()
 
-    disc, n_bins_actual, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
-    discretized_roi_voxels::Vector{Int} = disc[mask]
+    energy_val = get_energy_feature_value(roi_voxels)
+    first_order_features["firstorder_energy"] = energy_val
+    first_order_features["firstorder_total_energy"] = get_total_energy_feature_value(voxel_volume, energy_val)
 
-    p = get_voxel_probabilities(discretized_roi_voxels)
+    first_order_features["firstorder_entropy"] = get_entropy_feature_value(p_probs)
 
-    # Calculate in batch all percentiles in a single pass
-    perc = percentile(roi_voxels, [10, 25, 50, 75, 90])
-    percentile10 = perc[1]
-    percentile25 = perc[2]
-    median_val   = perc[3]
-    percentile75 = perc[4]
-    percentile90 = perc[5]
+    first_order_features["firstorder_minimum"] = vmin
+    first_order_features["firstorder_maximum"] = vmax
+    first_order_features["firstorder_mean"] = mean_val
+    first_order_features["firstorder_median"] = p50
+    first_order_features["firstorder_percentile10"] = p10
+    first_order_features["firstorder_percentile90"] = p90
+    first_order_features["firstorder_interquartile_range"] = p75 - p25
+    first_order_features["firstorder_range"] = vmax - vmin
 
-    mean_feature_value = mean(roi_voxels)
-    minimum_feature_value = minimum(roi_voxels)
-    maximum_feature_value = maximum(roi_voxels)
-
-    # Energy & Total Energy
-    energy_feature_value = get_energy_feature_value(roi_voxels)
-    first_order_features["firstorder_energy"] = energy_feature_value
-    first_order_features["firstorder_total_energy"] = get_total_energy_feature_value(voxel_volume, energy_feature_value)
-    
-    # Entropy
-    first_order_features["firstorder_entropy"] = get_entropy_feature_value(p)
-    
-    # Basic Stats
-    first_order_features["firstorder_minimum"] = minimum_feature_value
-    first_order_features["firstorder_percentile10"] = percentile10
-    first_order_features["firstorder_percentile90"] = percentile90
-    first_order_features["firstorder_maximum"] = maximum_feature_value
-    first_order_features["firstorder_mean"] = mean_feature_value
-    first_order_features["firstorder_median"] = median_val
-    first_order_features["firstorder_interquartile_range"] = percentile75 - percentile25
-    first_order_features["firstorder_range"] = maximum_feature_value - minimum_feature_value
-    first_order_features["firstorder_standard_deviation"] = std(roi_voxels)
-    
-    # Advanced Stats (Optimized to avoid dynamic allocations)
-    first_order_features["firstorder_mean_absolute_deviation"] = get_mean_absolute_deviation_feature_value(roi_voxels, mean_feature_value)
-    first_order_features["firstorder_robust_mean_absolute_deviation"] = get_robust_mean_absolute_deviation_feature_value(roi_voxels, percentile10, percentile90)
+    first_order_features["firstorder_mean_absolute_deviation"] = get_mean_absolute_deviation_feature_value(roi_voxels, mean_val)
+    first_order_features["firstorder_robust_mean_absolute_deviation"] = get_robust_mean_absolute_deviation_feature_value(roi_voxels, p10, p90)
     first_order_features["firstorder_root_mean_squared"] = get_root_mean_squared_feature_value(roi_voxels)
-    
-    skewness_val, kurtosis_val = get_skewness_and_kurtosis(roi_voxels, mean_feature_value)
+
+    skewness_val, kurtosis_val = get_skewness_and_kurtosis(roi_voxels, mean_val)
     first_order_features["firstorder_skewness"] = skewness_val
     first_order_features["firstorder_kurtosis"] = kurtosis_val
-    
-    first_order_features["firstorder_variance"] = get_variance_feature_value(roi_voxels, mean_feature_value)
-    first_order_features["firstorder_uniformity"] = get_uniformity_feature_value(p)
+
+    first_order_features["firstorder_variance"] = get_variance_feature_value(roi_voxels, mean_val)
+    first_order_features["firstorder_uniformity"] = get_uniformity_feature_value(p_probs)
+
+    first_order_features["firstorder_standard_deviation"] = sqrt(first_order_features["firstorder_variance"] * n / (n - 1))
 
     return first_order_features
 end

--- a/src/first_order_features.jl
+++ b/src/first_order_features.jl
@@ -11,7 +11,12 @@ using StatsBase
     - first_order_features::Dict{String, Float64}: Dictionary containing the extracted first order
       features
     """ 
-function get_first_order_features(img::Array{<:Real}, mask::BitArray, voxel_spacing::Vector{<:Real}; n_bins::Union{Int,Nothing}=nothing, bin_width::Union{Float64,Nothing}=nothing, verbose::Bool=false)
+function get_first_order_features(img::AbstractArray{Float64},
+                                   mask::BitArray,
+                                   voxel_spacing::Vector{Float64};
+                                   n_bins::Union{Int,Nothing}=nothing,
+                                   bin_width::Union{Float64,Nothing}=nothing,
+                                   verbose::Bool=false)::Dict{String,Any}
     if verbose
         println("Extracting first order features...")
     end

--- a/src/first_order_features.jl
+++ b/src/first_order_features.jl
@@ -130,7 +130,7 @@ end
     - entropy_feature_value::Float64: Calculated entropy feature value
     """
 function get_entropy_feature_value(p::Vector{Float64})::Float64
-    eps = 2.2204460492503131e-16
+    eps::Float64 = 2.2204460492503131e-16
     return -sum(p .* log2.(p .+ eps))
 end
 

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -109,38 +109,40 @@ function calculate_glcm(img::AbstractArray{Float64},
 
     mask_indices = findall(mask)
 
-    @inbounds for (dir_idx, dir) in enumerate(dirs)
-        """
+    """
         CartesianIndex represents a multidimensional index in Julia.
         By converting the direction (tuple) into a CartesianIndex, we can directly
         sum the current voxel index (idx) with the direction (c_dir) to obtain
         the neighboring voxel (nidx), without extracting individual coordinates.
         This works automatically for both 2D and 3D images.
         E.g: idx = CartesianIndex(3,4,2) + CartesianIndex(1,0,0) = CartesianIndex(4,4,2)
-        """
-        c_dir = CartesianIndex(dir)
-        G = zeros(Float64, Ng, Ng)
+    """
 
-        for idx in mask_indices
+    # Pre-allocating all the GLCMs
+    c_dirs = [CartesianIndex(dir) for dir in dirs]
+    G_all = [zeros(Float64, Ng, Ng) for _ in 1:length(dirs)]
+
+    @inbounds for idx in mask_indices
+        i_val = mapped_disc[idx]
+        for (dir_idx, c_dir) in enumerate(c_dirs)
             nidx = idx + c_dir
             if checkbounds(Bool, disc, nidx) && mask[nidx]
-                i = mapped_disc[idx]
-                j = mapped_disc[nidx]
-                # Symmetrize the GLCM
-                G[i, j] += 1.0f0
-                G[j, i] += 1.0f0
+                j_val = mapped_disc[nidx]
+                G_all[dir_idx][i_val, j_val] += 1.0
+                G_all[dir_idx][j_val, i_val] += 1.0
             end
         end
+    end
 
-        # Handle normalization based on weighting
+    # Normalization and weighting
+    @inbounds for dir_idx in 1:length(dirs)
+        G = G_all[dir_idx]
         if !isnothing(weighting_norm) && weighting_norm != "no_weighting"
-            # Apply weight WITHOUT normalizing yet
             if sum(G) > 0
                 @. G *= weights[dir_idx]
                 push!(glcm_matrices, G)
             end
         else
-            # No weighting: normalize each matrix separately
             total = sum(G)
             if total > 0
                 @. G /= total

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -1,13 +1,13 @@
 using LinearAlgebra
 using Statistics
 """ 
-    function calculate_glcm(img::Array{Float32,3}, mask::BitArray{3}, spacing::Vector{Float32}; n_bins::Union{Int,Nothing}=nothing, bin_width::Union{Float64,Nothing}=nothing, verbose::Bool=false)
+    function calculate_glcm(img::Array{Float64,3}, mask::BitArray{3}, spacing::Vector{Float64}; n_bins::Union{Int,Nothing}=nothing, bin_width::Union{Float64,Nothing}=nothing, verbose::Bool=false)
 
     Calculates the Gray Level Co-occurrence Matrix (GLCM) for a 3D image within a specified mask.
     You can specify EITHER n_bins OR bin_width, but not both.
 
     # Arguments
-        - `img`: The input 3D image as a Float32 array.
+        - `img`: The input 3D image as a Float64 array.
         - `mask`: A BitArray defining the region of interest within the image.
         - `spacing`: A vector specifying the voxel spacing in each dimension.
         - `n_bins`: The number of bins for discretizing intensity values (optional).
@@ -22,7 +22,7 @@ using Statistics
 """
 function calculate_glcm(img,
     mask,
-    spacing::Vector{Float32};
+    spacing::Vector{Float64};
     n_bins::Union{Int,Nothing}=nothing,
     bin_width::Union{Float64,Nothing}=nothing,
     weighting_norm::Union{String,Nothing}=nothing,
@@ -66,7 +66,7 @@ function calculate_glcm(img,
 
     Ng = length(gray_levels)
 
-    glcm_matrices = Vector{Matrix{Float32}}()
+    glcm_matrices = Vector{Matrix{Float64}}()
     sizehint!(glcm_matrices, length(dirs))
 
     # Pre-compute mapping from gray levels to indices directly into mapped_disc array
@@ -84,11 +84,11 @@ function calculate_glcm(img,
     end
 
     # Calculate weights if weighting is specified
-    weights = ones(Float32, length(dirs))
+    weights = ones(Float64, length(dirs))
     if !isnothing(weighting_norm) && weighting_norm != "no_weighting"
         current_spacing = Tuple(spacing[1:dim])
         @inbounds for (a_idx, dir) in enumerate(dirs)
-            abs_angle_dist = abs.(Float32.(dir)) .* current_spacing
+            abs_angle_dist = abs.(Float64.(dir)) .* current_spacing
 
             if weighting_norm == "infinity"
                 weights[a_idx] = exp(-maximum(abs_angle_dist)^2)
@@ -117,7 +117,7 @@ function calculate_glcm(img,
         E.g: idx = CartesianIndex(3,4,2) + CartesianIndex(1,0,0) = CartesianIndex(4,4,2)
         """
         c_dir = CartesianIndex(dir)
-        G = zeros(Float32, Ng, Ng)
+        G = zeros(Float64, Ng, Ng)
 
         for idx in CartesianIndices(disc)
             if mask[idx]
@@ -163,28 +163,28 @@ function calculate_glcm(img,
 end
 
 """
-    function calculate_mcc(glcm::Matrix{Float32}, px, py)
+    function calculate_mcc(glcm::Matrix{Float64}, px, py)
 
     Calculates the Maximal Correlation Coefficient (MCC) from a given GLCM and its marginal
     probabilities. The @inbounds macro is used for performance optimization.
 
     # Arguments:
-        - `glcm`: The Gray Level Co-occurrence Matrix as a Float32 matrix.
+        - `glcm`: The Gray Level Co-occurrence Matrix as a Float64 matrix.
         - `px`: The marginal probability vector for rows.
         - `py`: The marginal probability vector for columns.
 
     # Returns:
-        - The Maximal Correlation Coefficient as a Float32 value.
+        - The Maximal Correlation Coefficient as a Float64 value.
 """
-function calculate_mcc(glcm::Matrix{Float32}, px, py)
+function calculate_mcc(glcm::Matrix{Float64}, px, py)
     Ng = length(px)
     eps = 2.2f-16
     Ng < 2 && return 1.0f0
 
-    Q = zeros(Float32, Ng, Ng)
+    Q = zeros(Float64, Ng, Ng)
 
     # Pre-compute inverse of py values
-    inv_py = Vector{Float32}(undef, Ng)
+    inv_py = Vector{Float64}(undef, Ng)
     @inbounds for k in 1:Ng
         inv_py[k] = py[k] > eps ? 1.0f0 / py[k] : 0.0f0
     end
@@ -215,29 +215,29 @@ function calculate_mcc(glcm::Matrix{Float32}, px, py)
 end
 
 """
-    function extract_glcm_features(glcm::Matrix{Float32}, gray_levels::Vector{Int})
+    function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
 
     Extracts a set of GLCM features from a single GLCM matrix and its corresponding gray levels.
     The function utilizes the @inbounds macro for performance optimization.
 
     # Arguments:
-        - `glcm`: The Gray Level Co-occurrence Matrix as a Float32 matrix.
+        - `glcm`: The Gray Level Co-occurrence Matrix as a Float64 matrix.
         - `gray_levels`: A vector of gray levels corresponding to the GLCM.
 
     # Returns:
-        - A dictionary (Dict{String, Float32}) containing the extracted GLCM features.
+        - A dictionary (Dict{String, Float64}) containing the extracted GLCM features.
 """
-function extract_glcm_features(glcm::Matrix{Float32}, gray_levels::Vector{Int})
-    features = Dict{String,Float32}()
+function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
+    features = Dict{String,Float64}()
     n_levels = length(gray_levels)
-    eps = Float32(2.2e-16)
+    eps = Float64(2.2e-16)
 
     # Compute marginal probabilities
     px = vec(sum(glcm, dims=2))
     py = vec(sum(glcm, dims=1))
 
     # Convert gray levels once
-    gray_levels_f32 = Float32.(gray_levels)
+    gray_levels_f32 = Float64.(gray_levels)
 
     # Compute means
     μx = 0.0f0
@@ -260,10 +260,10 @@ function extract_glcm_features(glcm::Matrix{Float32}, gray_levels::Vector{Int})
     # Pre-allocate marginal distributions using actual gray level values
     max_gray_level = maximum(gray_levels)
     min_gray_level = minimum(gray_levels)
-    gray_level_range = Float32(max_gray_level - min_gray_level)
+    gray_level_range = Float64(max_gray_level - min_gray_level)
 
-    p_xminusy = zeros(Float32, max_gray_level - min_gray_level + 1)
-    p_xplusy = zeros(Float32, 2 * max_gray_level + 1)
+    p_xminusy = zeros(Float64, max_gray_level - min_gray_level + 1)
+    p_xplusy = zeros(Float64, 2 * max_gray_level + 1)
 
     # Pre-compute correlation denominator
     corr_denom = σx * σy
@@ -288,7 +288,7 @@ function extract_glcm_features(glcm::Matrix{Float32}, gray_levels::Vector{Int})
     sum_squares = 0.0f0
     diff_avg = 0.0f0  # accumulated here to avoid a second i×j pass below
 
-    ng = Float32(max_gray_level - min_gray_level + 1)
+    ng = Float64(max_gray_level - min_gray_level + 1)
 
     # Main feature extraction loop — also accumulates diff_avg and populates
     # p_xminusy/p_xplusy, so we avoid two extra O(n_levels^2) passes
@@ -349,7 +349,7 @@ function extract_glcm_features(glcm::Matrix{Float32}, gray_levels::Vector{Int})
                 p_xplusy[sum_val] += p
 
                 # Accumulate diff_avg in the same pass (avoids a second i×j loop)
-                diff_avg += Float32(diff_val) * p
+                diff_avg += Float64(diff_val) * p
             end
         end
     end
@@ -401,7 +401,7 @@ function extract_glcm_features(glcm::Matrix{Float32}, gray_levels::Vector{Int})
     sum_entropy = 0.0f0
     @inbounds for sum_k in min_k:max_k
         pk = p_xplusy[sum_k]
-        sum_avg += Float32(sum_k) * pk
+        sum_avg += Float64(sum_k) * pk
         if pk > 0
             sum_entropy -= pk * log2(pk + eps)
         end
@@ -466,7 +466,7 @@ end
     - If neither is specified, defaults to n_bins=32
 
     # Arguments
-        - `img`: The input 3D image as a Float32 array.
+        - `img`: The input 3D image as a Float64 array.
         - `mask`: A BitArray defining the region of interest within the image.
     - `voxel_spacing`: A vector specifying the voxel spacing in each dimension.
     - `n_bins`: The number of bins for discretizing intensity values (optional).
@@ -498,8 +498,8 @@ function get_glcm_features(img, mask, voxel_spacing;
     get_raw_matrices::Bool=false,
     verbose::Bool=false)
 
-    # Ensure spacing is Float32 and has the right length for the image dimensionality
-    spacing = convert(Vector{Float32}, voxel_spacing)
+    # Ensure spacing is Float64 and has the right length for the image dimensionality
+    spacing = convert(Vector{Float64}, voxel_spacing)
 
     glcm_matrices, gray_levels, bin_width_used = calculate_glcm(img, mask, spacing;
         n_bins=n_bins,
@@ -537,7 +537,7 @@ function get_glcm_features(img, mask, voxel_spacing;
         end
     end
 
-    inv_n = 1.0f0 / Float32(n_matrices)
+    inv_n = 1.0f0 / Float64(n_matrices)
     @inbounds for name in keys(sum_features)
         features[name] = sum_features[name] * inv_n
     end

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -48,8 +48,7 @@ function calculate_glcm(img::AbstractArray{Float64},
         else
             println("Calculating GLCM ($(dim)D) with default bin_width=25...")
         end
-        println("Intensity Range: [$(minimum(img[mask])), $(maximum(img[mask]))]")
-        println("Effective gray level utilized: $(n_levels)")
+
         println(dim == 2 ? "2D image detected. Using $(length(dirs)) directions." :
                            "3D image detected. Using $(length(dirs)) directions.")
         if weighting_norm !== nothing

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -31,21 +31,16 @@ function calculate_glcm(img::AbstractArray{Float64},
     disc, n_levels, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
     dim = ndims(disc)
-    dirs = if dim == 2
-        [(1, 0), (0, 1), (1, 1), (1, -1)]
-
-    else
+    dirs = dim == 2 ? 
+        [(1, 0), (0, 1), (1, 1), (1, -1)] : 
         [
             (1, 0, 0), (0, 1, 0), (0, 0, 1),
             (1, 1, 0), (1, -1, 0), (1, 0, 1), (1, 0, -1),
             (0, 1, 1), (0, 1, -1), (1, 1, 1), (1, 1, -1),
             (1, -1, 1), (-1, 1, 1)
         ]
-        
-    end
 
     if verbose
-
         if !isnothing(n_bins)
             println("Calculating GLCM ($(dim)D) with $(n_bins) bins...")
         elseif !isnothing(bin_width)
@@ -53,7 +48,6 @@ function calculate_glcm(img::AbstractArray{Float64},
         else
             println("Calculating GLCM ($(dim)D) with default bin_width=25...")
         end
-
         println("Intensity Range: [$(minimum(img[mask])), $(maximum(img[mask]))]")
         println("Effective gray level utilized: $(n_levels)")
         println(dim == 2 ? "2D image detected. Using $(length(dirs)) directions." :
@@ -61,15 +55,12 @@ function calculate_glcm(img::AbstractArray{Float64},
         if weighting_norm !== nothing
             println("Weighting norm applied: $(weighting_norm)")
         end
-
     end
 
     Ng = length(gray_levels)
-
     glcm_matrices = Vector{Matrix{Float64}}()
     sizehint!(glcm_matrices, length(dirs))
 
-    # Pre-compute mapping using LUT
     min_gl = Int(minimum(gray_levels))
     max_gl = Int(maximum(gray_levels))
     lut = zeros(Int, max_gl - min_gl + 1)
@@ -81,12 +72,10 @@ function calculate_glcm(img::AbstractArray{Float64},
     mapped_disc = zeros(Int, size(disc))
     @inbounds for i in CartesianIndices(disc)
         if mask[i]
-            #Direct access O(1) in memory.
             mapped_disc[i] = lut[disc[i] - min_gl + 1]
         end
     end
 
-    # Calculate weights if weighting is specified
     weights = ones(Float64, length(dirs))
     if !isnothing(weighting_norm) && weighting_norm != "no_weighting"
         current_spacing = Tuple(spacing[1:dim])
@@ -101,29 +90,17 @@ function calculate_glcm(img::AbstractArray{Float64},
                 weights[a_idx] = exp(-sum(abs_angle_dist)^2)
             else
                 @warn "Weighting norm \"$(weighting_norm)\" is unknown, weight set to 1"
-                weights[a_idx] = 1.0f0
+                weights[a_idx] = 1.0
             end
         end
-
-        if verbose
-            println("Weights computed: ", weights)
-        end
+        verbose && println("Weights computed: ", weights)
     end
 
     mask_indices = findall(mask)
-
-    """
-        CartesianIndex represents a multidimensional index in Julia.
-        By converting the direction (tuple) into a CartesianIndex, we can directly
-        sum the current voxel index (idx) with the direction (c_dir) to obtain
-        the neighboring voxel (nidx), without extracting individual coordinates.
-        This works automatically for both 2D and 3D images.
-        E.g: idx = CartesianIndex(3,4,2) + CartesianIndex(1,0,0) = CartesianIndex(4,4,2)
-    """
-
-    # Pre-allocating all the GLCMs
     c_dirs = [CartesianIndex(dir) for dir in dirs]
-    G_all = [zeros(Float64, Ng, Ng) for _ in 1:length(dirs)]
+    
+    # 3D tensor allocation to eliminate indirection and maximize cache
+    G_all = zeros(Float64, length(dirs), Ng, Ng)
 
     @inbounds for idx in mask_indices
         i_val = mapped_disc[idx]
@@ -131,30 +108,26 @@ function calculate_glcm(img::AbstractArray{Float64},
             nidx = idx + c_dir
             if checkbounds(Bool, disc, nidx) && mask[nidx]
                 j_val = mapped_disc[nidx]
-                G_all[dir_idx][i_val, j_val] += 1.0
-                G_all[dir_idx][j_val, i_val] += 1.0
+                G_all[dir_idx, i_val, j_val] += 1.0
+                G_all[dir_idx, j_val, i_val] += 1.0
             end
         end
     end
 
-    # Normalization and weighting
+    # Normalization and decomposition into flat matrices
     @inbounds for dir_idx in 1:length(dirs)
-        G = G_all[dir_idx]
-        if !isnothing(weighting_norm) && weighting_norm != "no_weighting"
-            if sum(G) > 0
+        G = G_all[dir_idx, :, :] # Slice out
+        total = sum(G)
+        if total > 0
+            if !isnothing(weighting_norm) && weighting_norm != "no_weighting"
                 @. G *= weights[dir_idx]
-                push!(glcm_matrices, G)
-            end
-        else
-            total = sum(G)
-            if total > 0
+            else
                 @. G /= total
-                push!(glcm_matrices, G)
             end
+            push!(glcm_matrices, G)
         end
     end
 
-    # If weighting is applied, sum all weighted matrices and normalize ONCE
     if !isnothing(weighting_norm) && weighting_norm != "no_weighting" && !isempty(glcm_matrices)
         summed_glcm = sum(glcm_matrices)
         total = sum(summed_glcm)
@@ -183,34 +156,26 @@ end
 """
 function calculate_mcc(glcm::Matrix{Float64}, px::Vector{Float64}, py::Vector{Float64})::Float64
     Ng = length(px)
-    eps = 2.2e-16
+    eps_val = 2.2e-16
     Ng < 2 && return 1.0
 
-    # Create the scaling factor
     inv_sqrt_p = Vector{Float64}(undef, Ng)
     @inbounds for i in 1:Ng
-        inv_sqrt_p[i] = px[i] > eps ? 1.0 / sqrt(px[i]) : 0.0
+        inv_sqrt_p[i] = px[i] > eps_val ? 1.0 / sqrt(px[i]) : 0.0
     end
 
-    # Construct the symmetric matrix S in O(Ng^2) instead of O(Ng^3)
-    S = zeros(Float64, Ng, Ng)
+    # 'undef' avoids initialization to zero, and we only calculate the upper triangle
+    S = Matrix{Float64}(undef, Ng, Ng)
     @inbounds for j in 1:Ng
         inv_sqrt_pj = inv_sqrt_p[j]
-        for i in 1:Ng
+        for i in 1:j
             S[i, j] = glcm[i, j] * inv_sqrt_p[i] * inv_sqrt_pj
         end
     end
 
     try
-        # Inform Julia that the matrix is symmetric.
-        # This activates native LA-PACK algorithms much faster.
-        eigs = eigvals(Symmetric(S))
-
-        # The eigenvalues of Q are the squares of eigs.
-        # Since the MCC is the square root of the second eigenvalue of Q,
-        # sqrt(λ^2) is simply the absolute value |λ|.
+        eigs = eigvals(Symmetric(S, :U)) # Exploit the upper triangle of the GLCM
         vals = sort(abs.(eigs), rev=true)
-        
         length(vals) >= 2 ? vals[2] : 0.0
     catch
         0.0
@@ -233,138 +198,135 @@ end
 function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})::Dict{String,Float64}
     features = Dict{String,Float64}()
     n_levels = length(gray_levels)
-    eps = Float64(2.2e-16)
+    eps_val = 2.2e-16
 
-    # Compute marginal probabilities
+    # Exploit the symmetry of the GLCM. px and py are identical.
     px = vec(sum(glcm, dims=2))
-    py = vec(sum(glcm, dims=1))
+    py = px 
 
-    # Convert gray levels once
     gl = Float64.(gray_levels)
 
-    # Compute means
+    # Identical means and variances on both dimensions
     μx = 0.0
-    μy = 0.0
     for i in 1:n_levels
         μx += gl[i] * px[i]
-        μy += gl[i] * py[i]
     end
+    μy = μx
 
-    # Compute standard deviations
     σx_sq = 0.0
-    σy_sq = 0.0
     for i in 1:n_levels
         σx_sq += (gl[i] - μx)^2 * px[i]
-        σy_sq += (gl[i] - μy)^2 * py[i]
     end
     σx = sqrt(σx_sq)
-    σy = sqrt(σy_sq)
+    σy = σx
 
-    # Pre-allocate marginal distributions using actual gray level values
     max_gray_level = maximum(gray_levels)
     min_gray_level = minimum(gray_levels)
-    gray_level_range = Float64(max_gray_level - min_gray_level)
-
+    
     p_xminusy = zeros(Float64, max_gray_level - min_gray_level + 1)
     p_xplusy = zeros(Float64, 2 * max_gray_level + 1)
 
-    # Pre-compute correlation denominator
-    corr_denom = σx * σy
+    corr_denom = σx_sq
     use_corr = corr_denom > 0
     inv_corr_denom = use_corr ? 1.0 / corr_denom : 0.0
 
-    # Initialize feature accumulators
-    autocorr = 0.0
-    cluster_prom = 0.0
-    cluster_shade = 0.0
-    cluster_tend = 0.0
-    contrast = 0.0
-    correlation = 0.0
-    joint_energy = 0.0
-    joint_entropy = 0.0
-    idm = 0.0
-    idmn = 0.0
-    id = 0.0
-    idn = 0.0
-    inv_var = 0.0
-    max_prob = 0.0
-    sum_squares = 0.0
-    diff_avg = 0.0
-    diff_sq_avg = 0.0
-    HXY1 = 0.0
-    HXY2 = 0.0
+    autocorr = cluster_prom = cluster_shade = cluster_tend = contrast = correlation = 0.0
+    joint_energy = joint_entropy = idm = idmn = id = idn = inv_var = max_prob = sum_squares = 0.0
+    diff_avg = diff_sq_avg = HXY1 = 0.0
 
     ng = Float64(max_gray_level - min_gray_level + 1)
 
+    # Triangular cycle (j >= i). Reduces the total iterations by 50%.
     @inbounds @fastmath for i in 1:n_levels
         xi = gl[i]
         xi_minus_μx = xi - μx
 
-        for j in 1:n_levels
-            p = glcm[i, j]
-
-            # Information measures
-            pxpy = px[i] * py[j]
-            if pxpy > 0
-                log_pxpy = log2(pxpy + eps)
-                HXY2 -= pxpy * log_pxpy
-                if p > 0
-                    HXY1 -= p * log_pxpy
-                end
+        # 1. Elements on the diagonal (j == i)
+        p_diag = glcm[i, i]
+        if p_diag > 0
+            autocorr += xi * xi * p_diag
+            s = 2.0 * xi_minus_μx
+            s2 = s * s
+            cluster_tend += s2 * p_diag
+            cluster_shade += s * s2 * p_diag
+            cluster_prom += s2 * s2 * p_diag
+            
+            if use_corr
+                correlation += xi_minus_μx * xi_minus_μx * p_diag * inv_corr_denom
             end
+            
+            joint_energy += p_diag * p_diag
+            joint_entropy -= p_diag * log2(p_diag + eps_val)
+            sum_squares += xi_minus_μx * xi_minus_μx * p_diag
+            
+            # d = 0, so the divisors collapse to 1.0
+            idm += p_diag
+            id += p_diag
+            idmn += p_diag
+            idn += p_diag
+            
+            max_prob = max(max_prob, p_diag)
+            p_xminusy[1] += p_diag
+            
+            sum_val = gray_levels[i] + gray_levels[i]
+            p_xplusy[sum_val] += p_diag
+            
+            pxpy = px[i] * px[i]
+            if pxpy > 0
+                HXY1 -= p_diag * log2(pxpy + eps_val)
+            end
+        end
 
+        # 2. Off-diagonal elements (j > i) - Multiplied by 2.0 due to symmetry
+        for j in (i+1):n_levels
+            p = glcm[i, j]
             if p > 0
                 yj = gl[j]
-                yj_minus_μy = yj - μy
-
-                # Autocorrelation
-                autocorr += xi * yj * p
-
-                # Cluster features
-                s = xi_minus_μx + yj_minus_μy
+                yj_minus_μx = yj - μx
+                
+                autocorr += 2.0 * (xi * yj * p)
+                
+                s = xi_minus_μx + yj_minus_μx
                 s2 = s * s
-                cluster_tend += s2 * p
-                cluster_shade += s * s2 * p
-                cluster_prom += s2 * s2 * p
-
-                # Difference
+                cluster_tend += 2.0 * (s2 * p)
+                cluster_shade += 2.0 * (s * s2 * p)
+                cluster_prom += 2.0 * (s2 * s2 * p)
+                
                 d = xi - yj
                 d2 = d * d
-                contrast += d2 * p
-
-                # Correlation
-                if use_corr
-                    correlation += xi_minus_μx * yj_minus_μy * p * inv_corr_denom
-                end
-
-                # Energy and entropy
-                joint_energy += p * p
-                joint_entropy -= p * log2(p + eps)
-                sum_squares += xi_minus_μx * xi_minus_μx * p
-
-                # Inverse difference features
                 absd = abs(d)
-                idm += p / (1.0f0 + d2)
-                id += p / (1.0f0 + absd)
-                idmn += p / (1.0f0 + (absd / ng)^2)
-                idn  += p / (1.0f0 + absd / ng)
-
-                # Inverse variance
-                if i != j
-                    inv_var += p / d2
+                contrast += 2.0 * (d2 * p)
+                
+                if use_corr
+                    correlation += 2.0 * (xi_minus_μx * yj_minus_μx * p * inv_corr_denom)
                 end
-
-                # Maximum probability
+                
+                joint_energy += 2.0 * (p * p)
+                joint_entropy -= 2.0 * (p * log2(p + eps_val))
+                
+                sum_squares += (xi_minus_μx * xi_minus_μx + yj_minus_μx * yj_minus_μx) * p
+                
+                idm += 2.0 * (p / (1.0 + d2))
+                id += 2.0 * (p / (1.0 + absd))
+                idmn += 2.0 * (p / (1.0 + (absd / ng)^2))
+                idn  += 2.0 * (p / (1.0 + absd / ng))
+                
+                inv_var += 2.0 * (p / d2)
                 max_prob = max(max_prob, p)
-
-                # Populate marginal distributions using gray level VALUES
+                
                 diff_val = abs(gray_levels[i] - gray_levels[j])
+                p_xminusy[diff_val + 1] += 2.0 * p
+                
                 sum_val = gray_levels[i] + gray_levels[j]
-                p_xminusy[diff_val + 1] += p
-                p_xplusy[sum_val] += p
-
-                diff_avg += absd * p
-                diff_sq_avg += (absd^2) * p
+                p_xplusy[sum_val] += 2.0 * p
+                
+                diff_avg += 2.0 * (absd * p)
+                diff_sq_avg += 2.0 * (d2 * p)
+                
+                pxpy = px[i] * px[j]
+                if pxpy > 0
+                    HXY1 -= 2.0 * (p * log2(pxpy + eps_val))
+                end
             end
         end
     end
@@ -385,61 +347,46 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int}):
     features["glcm_MaximumProbability"] = max_prob
     features["glcm_DifferenceAverage"] = diff_avg
 
-    # Difference entropy from p_xminusy
     diff_entropy = 0.0
     @inbounds for k in 1:length(p_xminusy)
         pk = p_xminusy[k]
         if pk > 0
-            diff_entropy -= pk * log2(pk + eps)
+            diff_entropy -= pk * log2(pk + eps_val)
         end
     end
-
-    # Difference variance
-    diff_var = diff_sq_avg - diff_avg^2
-
     features["glcm_DifferenceEntropy"] = diff_entropy
-    features["glcm_DifferenceVariance"] = diff_var
+    features["glcm_DifferenceVariance"] = diff_sq_avg - diff_avg^2
 
-    # Sum features
     min_k = 2 * min_gray_level
     max_k = 2 * max_gray_level
-
-    sum_avg = 0.0
-    sum_entropy = 0.0
+    sum_avg = sum_entropy = 0.0
     @inbounds for sum_k in min_k:max_k
         pk = p_xplusy[sum_k]
         sum_avg += Float64(sum_k) * pk
         if pk > 0
-            sum_entropy -= pk * log2(pk + eps)
+            sum_entropy -= pk * log2(pk + eps_val)
         end
     end
 
     features["glcm_SumAverage"] = sum_avg
     features["glcm_SumEntropy"] = sum_entropy
     features["glcm_SumSquares"] = sum_squares
-
-    # Joint average
     features["glcm_JointAverage"] = μx
 
-    # Marginal entropies
     HX = 0.0
-    HY = 0.0
     @inbounds for i in 1:n_levels
-        pxi = px[i]
-        pyi = py[i]
-        if pxi > 0
-            HX -= pxi * log2(pxi + eps)
-        end
-        if pyi > 0
-            HY -= pyi * log2(pyi + eps)
+        if px[i] > 0
+            HX -= px[i] * log2(px[i] + eps_val)
         end
     end
+    HY = HX
     HXY = joint_entropy
 
-    div = max(HX, HY)
-    features["glcm_Imc1"] = div > 0 ? (HXY - HXY1) / div : 0.0
-    features["glcm_Imc2"] = HXY2 > HXY ? sqrt(1.0f0 - exp(-2.0f0 * (HXY2 - HXY))) : 0.0
+    HXY2 = HX + HY
 
+    div_val = max(HX, HY)
+    features["glcm_Imc1"] = div_val > 0 ? (HXY - HXY1) / div_val : 0.0
+    features["glcm_Imc2"] = HXY2 > HXY ? sqrt(1.0 - exp(-2.0 * (HXY2 - HXY))) : 0.0
     features["glcm_Mcc"] = calculate_mcc(glcm, px, py)
 
     return features

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -69,17 +69,20 @@ function calculate_glcm(img::AbstractArray{Float64},
     glcm_matrices = Vector{Matrix{Float64}}()
     sizehint!(glcm_matrices, length(dirs))
 
-    # Pre-compute mapping from gray levels to indices directly into mapped_disc array
-    map_bin = Dict{Int,Int}()
-    sizehint!(map_bin, Ng)
+    # Pre-compute mapping using LUT
+    min_gl = Int(minimum(gray_levels))
+    max_gl = Int(maximum(gray_levels))
+    lut = zeros(Int, max_gl - min_gl + 1)
+
     @inbounds for (i, gl) in enumerate(gray_levels)
-        map_bin[Int(gl)] = i
+        lut[Int(gl) - min_gl + 1] = i
     end
 
     mapped_disc = zeros(Int, size(disc))
     @inbounds for i in CartesianIndices(disc)
         if mask[i]
-            mapped_disc[i] = map_bin[disc[i]]
+            #Direct access O(1) in memory.
+            mapped_disc[i] = lut[disc[i] - min_gl + 1]
         end
     end
 
@@ -180,37 +183,35 @@ end
 """
 function calculate_mcc(glcm::Matrix{Float64}, px::Vector{Float64}, py::Vector{Float64})::Float64
     Ng = length(px)
-    eps = 2.2f-16
-    Ng < 2 && return 1.0f0
+    eps = 2.2e-16
+    Ng < 2 && return 1.0
 
-    Q = zeros(Float64, Ng, Ng)
-
-    # Pre-compute inverse of py values
-    inv_py = Vector{Float64}(undef, Ng)
-    @inbounds for k in 1:Ng
-        inv_py[k] = py[k] > eps ? 1.0f0 / py[k] : 0.0
+    # Create the scaling factor
+    inv_sqrt_p = Vector{Float64}(undef, Ng)
+    @inbounds for i in 1:Ng
+        inv_sqrt_p[i] = px[i] > eps ? 1.0 / sqrt(px[i]) : 0.0
     end
 
-    # Compute Q matrix
-    @inbounds for i in 1:Ng
-        if px[i] > eps
-            inv_pxi = 1.0f0 / px[i]
-            for j in 1:Ng
-                s = 0.0
-                for k in 1:Ng
-                    if py[k] > eps
-                        s += glcm[i, k] * glcm[j, k] * inv_py[k]
-                    end
-                end
-                Q[i, j] = s * inv_pxi
-            end
+    # Construct the symmetric matrix S in O(Ng^2) instead of O(Ng^3)
+    S = zeros(Float64, Ng, Ng)
+    @inbounds for j in 1:Ng
+        inv_sqrt_pj = inv_sqrt_p[j]
+        for i in 1:Ng
+            S[i, j] = glcm[i, j] * inv_sqrt_p[i] * inv_sqrt_pj
         end
     end
 
     try
-        eigs = eigvals(Q)
-        vals = sort(real.(eigs), rev=true)
-        (length(vals) >= 2 && vals[2] > 0) ? sqrt(vals[2]) : 0.0
+        # Inform Julia that the matrix is symmetric.
+        # This activates native LA-PACK algorithms much faster.
+        eigs = eigvals(Symmetric(S))
+
+        # The eigenvalues of Q are the squares of eigs.
+        # Since the MCC is the square root of the second eigenvalue of Q,
+        # sqrt(λ^2) is simply the absolute value |λ|.
+        vals = sort(abs.(eigs), rev=true)
+        
+        length(vals) >= 2 ? vals[2] : 0.0
     catch
         0.0
     end
@@ -239,22 +240,22 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int}):
     py = vec(sum(glcm, dims=1))
 
     # Convert gray levels once
-    gray_levels_f32 = Float64.(gray_levels)
+    gl = Float64.(gray_levels)
 
     # Compute means
     μx = 0.0
     μy = 0.0
     for i in 1:n_levels
-        μx += gray_levels_f32[i] * px[i]
-        μy += gray_levels_f32[i] * py[i]
+        μx += gl[i] * px[i]
+        μy += gl[i] * py[i]
     end
 
     # Compute standard deviations
     σx_sq = 0.0
     σy_sq = 0.0
     for i in 1:n_levels
-        σx_sq += (gray_levels_f32[i] - μx)^2 * px[i]
-        σy_sq += (gray_levels_f32[i] - μy)^2 * py[i]
+        σx_sq += (gl[i] - μx)^2 * px[i]
+        σy_sq += (gl[i] - μy)^2 * py[i]
     end
     σx = sqrt(σx_sq)
     σy = sqrt(σy_sq)
@@ -295,10 +296,8 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int}):
 
     ng = Float64(max_gray_level - min_gray_level + 1)
 
-    # Main feature extraction loop — also accumulates diff_avg and populates
-    # p_xminusy/p_xplusy, so we avoid two extra O(n_levels^2) passes
-    @inbounds for i in 1:n_levels
-        xi = gray_levels_f32[i]
+    @inbounds @fastmath for i in 1:n_levels
+        xi = gl[i]
         xi_minus_μx = xi - μx
 
         for j in 1:n_levels
@@ -315,7 +314,7 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int}):
             end
 
             if p > 0
-                yj = gray_levels_f32[j]
+                yj = gl[j]
                 yj_minus_μy = yj - μy
 
                 # Autocorrelation
@@ -364,9 +363,8 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int}):
                 p_xminusy[diff_val + 1] += p
                 p_xplusy[sum_val] += p
 
-                # Accumulate diff_avg in the same pass (avoids a second i×j loop)
-                diff_avg += Float64(diff_val) * p
-                diff_sq_avg += Float64(diff_val)^2 * p
+                diff_avg += absd * p
+                diff_sq_avg += (absd^2) * p
             end
         end
     end
@@ -387,7 +385,7 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int}):
     features["glcm_MaximumProbability"] = max_prob
     features["glcm_DifferenceAverage"] = diff_avg
 
-    # Difference entropy from p_xminusy (single pass over p_xminusy, no extra i×j loop)
+    # Difference entropy from p_xminusy
     diff_entropy = 0.0
     @inbounds for k in 1:length(p_xminusy)
         pk = p_xminusy[k]
@@ -494,51 +492,50 @@ function get_glcm_features(img::AbstractArray{Float64},
                             get_raw_matrices::Bool=false,
                             verbose::Bool=false)::Dict{String,Any}
 
-    # Ensure spacing is Float64 and has the right length for the image dimensionality
-    spacing = convert(Vector{Float64}, voxel_spacing)
-
-    glcm_matrices, gray_levels, bin_width_used = calculate_glcm(img, mask, spacing;
+    glcm_matrices, gray_levels, bin_width_used = calculate_glcm(img, mask, voxel_spacing;
         n_bins=n_bins,
         bin_width=bin_width,
         weighting_norm=weighting_norm,
         verbose=verbose)
 
-    features = Dict{String, Any}()
-
     if isempty(glcm_matrices)
-        return features
+        return Dict{String, Any}() 
     end
 
     if get_raw_matrices
         if verbose
             println("=================================")
-            println("GLCM Matrix Dimensions: $(size(glcm_matrices[1]))  →  $(size(glcm_matrices[1],1)) gray levels × $(size(glcm_matrices[1],2)) gray levels")
+            println("GLCM Matrix Dimensions: $(size(glcm_matrices[1]))")
             println("Number of directional matrices saved: $(length(glcm_matrices))")
-            println("GLCM saved in dictionary.")
             println("=================================")
         end
-        features["raw_glcm_matrices"] = glcm_matrices
-        return features
+
+        return Dict{String, Any}("raw_glcm_matrices" => glcm_matrices)
     end
 
-    # Accumulate features directly into a single sum dictionary instead of
-    # allocating N separate feature dicts and averaging after — saves N-1 Dict allocations
     n_matrices = length(glcm_matrices)
-    sum_features = extract_glcm_features(glcm_matrices[1], gray_levels)
+    inv_n = 1.0 / Float64(n_matrices)
+    
+    final_features = Dict{String, Any}()
+
+
+    f1 = extract_glcm_features(glcm_matrices[1], gray_levels)
+    for (name, val) in f1
+        final_features[name] = val
+    end
 
     @inbounds for k in 2:n_matrices
         f = extract_glcm_features(glcm_matrices[k], gray_levels)
         for (name, val) in f
-            sum_features[name] += val
+            final_features[name] += val
         end
     end
 
-    inv_n = 1.0f0 / Float64(n_matrices)
-    @inbounds for name in keys(sum_features)
-        features[name] = sum_features[name] * inv_n
+    for (name, val) in final_features
+        final_features[name] = val * inv_n
     end
 
-    verbose && println("Completed! Extracted $(length(features)) features.")
+    verbose && println("Completed! Extracted $(length(final_features)) features.")
 
-    return features
+    return final_features 
 end

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -20,13 +20,13 @@ using Statistics
         - `gray_levels`: A vector of unique gray levels present in the ROI.
         - `bin_width_used`: The bin width used for discretization.
 """
-function calculate_glcm(img,
-    mask,
-    spacing::Vector{Float64};
-    n_bins::Union{Int,Nothing}=nothing,
-    bin_width::Union{Float64,Nothing}=nothing,
-    weighting_norm::Union{String,Nothing}=nothing,
-    verbose::Bool=false)
+function calculate_glcm(img::AbstractArray{Float64},
+                         mask::BitArray,
+                         spacing::Vector{Float64};
+                         n_bins::Union{Int,Nothing}=nothing,
+                         bin_width::Union{Float64,Nothing}=nothing,
+                         weighting_norm::Union{String,Nothing}=nothing,
+                         verbose::Bool=false)::Tuple{Vector{Matrix{Float64}}, Vector{Int}, Float64}
 
     disc, n_levels, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
@@ -163,7 +163,7 @@ function calculate_glcm(img,
 end
 
 """
-    function calculate_mcc(glcm::Matrix{Float64}, px, py)
+    function calculate_mcc(glcm::Matrix{Float64}, px::Vector{Float64}, py::Vector{Float64})::Float64
 
     Calculates the Maximal Correlation Coefficient (MCC) from a given GLCM and its marginal
     probabilities. The @inbounds macro is used for performance optimization.
@@ -176,7 +176,7 @@ end
     # Returns:
         - The Maximal Correlation Coefficient as a Float64 value.
 """
-function calculate_mcc(glcm::Matrix{Float64}, px, py)
+function calculate_mcc(glcm::Matrix{Float64}, px::Vector{Float64}, py::Vector{Float64})::Float64
     Ng = length(px)
     eps = 2.2f-16
     Ng < 2 && return 1.0f0
@@ -215,7 +215,7 @@ function calculate_mcc(glcm::Matrix{Float64}, px, py)
 end
 
 """
-    function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
+    function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})::Dict{String,Float64}
 
     Extracts a set of GLCM features from a single GLCM matrix and its corresponding gray levels.
     The function utilizes the @inbounds macro for performance optimization.
@@ -227,7 +227,7 @@ end
     # Returns:
         - A dictionary (Dict{String, Float64}) containing the extracted GLCM features.
 """
-function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
+function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})::Dict{String,Float64}
     features = Dict{String,Float64}()
     n_levels = length(gray_levels)
     eps = Float64(2.2e-16)
@@ -483,12 +483,14 @@ end
     # With weighting
     features = get_glcm_features(img, mask, spacing, weighting_norm="euclidean")
 """
-function get_glcm_features(img, mask, voxel_spacing;
-    n_bins::Union{Int,Nothing}=nothing,
-    bin_width::Union{Float64,Nothing}=nothing,
-    weighting_norm::Union{String,Nothing}=nothing,
-    get_raw_matrices::Bool=false,
-    verbose::Bool=false)
+function get_glcm_features(img::AbstractArray{Float64},
+                            mask::BitArray,
+                            voxel_spacing::Vector{Float64};
+                            n_bins::Union{Int,Nothing}=nothing,
+                            bin_width::Union{Float64,Nothing}=nothing,
+                            weighting_norm::Union{String,Nothing}=nothing,
+                            get_raw_matrices::Bool=false,
+                            verbose::Bool=false)::Dict{String,Any}
 
     # Ensure spacing is Float64 and has the right length for the image dimensionality
     spacing = convert(Vector{Float64}, voxel_spacing)

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -107,6 +107,8 @@ function calculate_glcm(img,
         end
     end
 
+    mask_indices = findall(mask)
+
     @inbounds for (dir_idx, dir) in enumerate(dirs)
         """
         CartesianIndex represents a multidimensional index in Julia.
@@ -119,16 +121,14 @@ function calculate_glcm(img,
         c_dir = CartesianIndex(dir)
         G = zeros(Float64, Ng, Ng)
 
-        for idx in CartesianIndices(disc)
-            if mask[idx]
-                nidx = idx + c_dir
-                if checkbounds(Bool, disc, nidx) && mask[nidx]
-                    i = mapped_disc[idx]
-                    j = mapped_disc[nidx]
-                    # Symmetrize the GLCM
-                    G[i, j] += 1.0f0
-                    G[j, i] += 1.0f0
-                end
+        for idx in mask_indices
+            nidx = idx + c_dir
+            if checkbounds(Bool, disc, nidx) && mask[nidx]
+                i = mapped_disc[idx]
+                j = mapped_disc[nidx]
+                # Symmetrize the GLCM
+                G[i, j] += 1.0f0
+                G[j, i] += 1.0f0
             end
         end
 
@@ -186,7 +186,7 @@ function calculate_mcc(glcm::Matrix{Float64}, px, py)
     # Pre-compute inverse of py values
     inv_py = Vector{Float64}(undef, Ng)
     @inbounds for k in 1:Ng
-        inv_py[k] = py[k] > eps ? 1.0f0 / py[k] : 0.0f0
+        inv_py[k] = py[k] > eps ? 1.0f0 / py[k] : 0.0
     end
 
     # Compute Q matrix
@@ -194,7 +194,7 @@ function calculate_mcc(glcm::Matrix{Float64}, px, py)
         if px[i] > eps
             inv_pxi = 1.0f0 / px[i]
             for j in 1:Ng
-                s = 0.0f0
+                s = 0.0
                 for k in 1:Ng
                     if py[k] > eps
                         s += glcm[i, k] * glcm[j, k] * inv_py[k]
@@ -208,9 +208,9 @@ function calculate_mcc(glcm::Matrix{Float64}, px, py)
     try
         eigs = eigvals(Q)
         vals = sort(real.(eigs), rev=true)
-        (length(vals) >= 2 && vals[2] > 0) ? sqrt(vals[2]) : 0.0f0
+        (length(vals) >= 2 && vals[2] > 0) ? sqrt(vals[2]) : 0.0
     catch
-        0.0f0
+        0.0
     end
 end
 
@@ -240,16 +240,16 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
     gray_levels_f32 = Float64.(gray_levels)
 
     # Compute means
-    μx = 0.0f0
-    μy = 0.0f0
+    μx = 0.0
+    μy = 0.0
     for i in 1:n_levels
         μx += gray_levels_f32[i] * px[i]
         μy += gray_levels_f32[i] * py[i]
     end
 
     # Compute standard deviations
-    σx_sq = 0.0f0
-    σy_sq = 0.0f0
+    σx_sq = 0.0
+    σy_sq = 0.0
     for i in 1:n_levels
         σx_sq += (gray_levels_f32[i] - μx)^2 * px[i]
         σy_sq += (gray_levels_f32[i] - μy)^2 * py[i]
@@ -268,25 +268,28 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
     # Pre-compute correlation denominator
     corr_denom = σx * σy
     use_corr = corr_denom > 0
-    inv_corr_denom = use_corr ? 1.0f0 / corr_denom : 0.0f0
+    inv_corr_denom = use_corr ? 1.0 / corr_denom : 0.0
 
     # Initialize feature accumulators
-    autocorr = 0.0f0
-    cluster_prom = 0.0f0
-    cluster_shade = 0.0f0
-    cluster_tend = 0.0f0
-    contrast = 0.0f0
-    correlation = 0.0f0
-    joint_energy = 0.0f0
-    joint_entropy = 0.0f0
-    idm = 0.0f0
-    idmn = 0.0f0
-    id = 0.0f0
-    idn = 0.0f0
-    inv_var = 0.0f0
-    max_prob = 0.0f0
-    sum_squares = 0.0f0
-    diff_avg = 0.0f0  # accumulated here to avoid a second i×j pass below
+    autocorr = 0.0
+    cluster_prom = 0.0
+    cluster_shade = 0.0
+    cluster_tend = 0.0
+    contrast = 0.0
+    correlation = 0.0
+    joint_energy = 0.0
+    joint_entropy = 0.0
+    idm = 0.0
+    idmn = 0.0
+    id = 0.0
+    idn = 0.0
+    inv_var = 0.0
+    max_prob = 0.0
+    sum_squares = 0.0
+    diff_avg = 0.0
+    diff_sq_avg = 0.0
+    HXY1 = 0.0
+    HXY2 = 0.0
 
     ng = Float64(max_gray_level - min_gray_level + 1)
 
@@ -298,6 +301,17 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
 
         for j in 1:n_levels
             p = glcm[i, j]
+
+            # Information measures
+            pxpy = px[i] * py[j]
+            if pxpy > 0
+                log_pxpy = log2(pxpy + eps)
+                HXY2 -= pxpy * log_pxpy
+                if p > 0
+                    HXY1 -= p * log_pxpy
+                end
+            end
+
             if p > 0
                 yj = gray_levels_f32[j]
                 yj_minus_μy = yj - μy
@@ -350,6 +364,7 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
 
                 # Accumulate diff_avg in the same pass (avoids a second i×j loop)
                 diff_avg += Float64(diff_val) * p
+                diff_sq_avg += Float64(diff_val)^2 * p
             end
         end
     end
@@ -371,7 +386,7 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
     features["glcm_DifferenceAverage"] = diff_avg
 
     # Difference entropy from p_xminusy (single pass over p_xminusy, no extra i×j loop)
-    diff_entropy = 0.0f0
+    diff_entropy = 0.0
     @inbounds for k in 1:length(p_xminusy)
         pk = p_xminusy[k]
         if pk > 0
@@ -379,16 +394,8 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
         end
     end
 
-    # Difference variance — requires diff_avg, which was computed in the main loop above,
-    # so this is now the only remaining extra i×j pass (unavoidable without two-pass logic)
-    diff_var = 0.0f0
-    @inbounds for i in 1:n_levels, j in 1:n_levels
-        p = glcm[i, j]
-        if p > 0
-            diff_val = abs(gray_levels_f32[i] - gray_levels_f32[j])
-            diff_var += (diff_val - diff_avg)^2 * p
-        end
-    end
+    # Difference variance
+    diff_var = diff_sq_avg - diff_avg^2
 
     features["glcm_DifferenceEntropy"] = diff_entropy
     features["glcm_DifferenceVariance"] = diff_var
@@ -397,8 +404,8 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
     min_k = 2 * min_gray_level
     max_k = 2 * max_gray_level
 
-    sum_avg = 0.0f0
-    sum_entropy = 0.0f0
+    sum_avg = 0.0
+    sum_entropy = 0.0
     @inbounds for sum_k in min_k:max_k
         pk = p_xplusy[sum_k]
         sum_avg += Float64(sum_k) * pk
@@ -415,8 +422,8 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
     features["glcm_JointAverage"] = μx
 
     # Marginal entropies
-    HX = 0.0f0
-    HY = 0.0f0
+    HX = 0.0
+    HY = 0.0
     @inbounds for i in 1:n_levels
         pxi = px[i]
         pyi = py[i]
@@ -429,24 +436,9 @@ function extract_glcm_features(glcm::Matrix{Float64}, gray_levels::Vector{Int})
     end
     HXY = joint_entropy
 
-    # Information measures of correlation
-    HXY1 = 0.0f0
-    HXY2 = 0.0f0
-    @inbounds for i in 1:n_levels, j in 1:n_levels
-        pij = glcm[i, j]
-        pxpy = px[i] * py[j]
-        if pxpy > 0
-            log_pxpy = log2(pxpy + eps)
-            HXY2 -= pxpy * log_pxpy
-            if pij > 0
-                HXY1 -= pij * log_pxpy
-            end
-        end
-    end
-
     div = max(HX, HY)
-    features["glcm_Imc1"] = div > 0 ? (HXY - HXY1) / div : 0.0f0
-    features["glcm_Imc2"] = HXY2 > HXY ? sqrt(1.0f0 - exp(-2.0f0 * (HXY2 - HXY))) : 0.0f0
+    features["glcm_Imc1"] = div > 0 ? (HXY - HXY1) / div : 0.0
+    features["glcm_Imc2"] = HXY2 > HXY ? sqrt(1.0f0 - exp(-2.0f0 * (HXY2 - HXY))) : 0.0
 
     features["glcm_Mcc"] = calculate_mcc(glcm, px, py)
 
@@ -475,10 +467,10 @@ end
     - `get_raw_matrices`: If true, returns one raw (unnormalized, unweighted) GLCM matrix per direction instead of the standard aggregated result.
     - `verbose`: If true, enables verbose output for debugging or detailed processing information.
     
-# Returns:
+    # Returns:
     - `feats`: A dictionary containing the mean GLCM features across all directions.
     
-# Examples:
+    # Examples:
     # Using fixed number of bins (bin_width calculated automatically)
     features = get_glcm_features(img, mask, spacing, n_bins=64)
         

--- a/src/gldm_features.jl
+++ b/src/gldm_features.jl
@@ -34,12 +34,14 @@ using StatsBase
         # Default (32 bins)
         features = get_gldm_features(img, mask, spacing)
 """
-function get_gldm_features(img, mask, voxel_spacing;
-    n_bins::Union{Int,Nothing}=nothing,
-    bin_width::Union{Float64,Nothing}=nothing,
-    gldm_a=0,
-    get_raw_matrices::Bool=false,
-    verbose=false)
+function get_gldm_features(img::AbstractArray{Float64},
+                            mask::BitArray,
+                            voxel_spacing::Vector{Float64};
+                            n_bins::Union{Int,Nothing}=nothing,
+                            bin_width::Union{Float64,Nothing}=nothing,
+                            gldm_a::Int=0,
+                            get_raw_matrices::Bool=false,
+                            verbose::Bool=false)::Dict{String,Any}
     if verbose
         if !isnothing(n_bins)
             println("Calculating GLDM with $(n_bins) bins...")
@@ -104,7 +106,10 @@ function get_gldm_features(img, mask, voxel_spacing;
 end
 
 """
-    calculate_gldm_matrix(discretized_img, mask, gldm_a, verbose)
+    calculate_gldm_matrix(discretized_img::Array{Int},
+                                mask::BitArray,
+                                gldm_a::Int,
+                                verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
 
     Calculates the Gray Level Dependence Matrix (GLDM).
 
@@ -117,7 +122,10 @@ end
     # Returns
     - A tuple containing the GLDM matrix and the gray levels present in the ROI.
 """
-function calculate_gldm_matrix(discretized_img, mask, gldm_a, verbose)
+function calculate_gldm_matrix(discretized_img::Array{Int},
+                                mask::BitArray,
+                                gldm_a::Int,
+                                verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
     if verbose
         println("Calculating GLDM matrix...")
     end
@@ -165,7 +173,8 @@ function calculate_gldm_matrix(discretized_img, mask, gldm_a, verbose)
 end
 
 """
-    calculate_gldm_coefficients(P_gldm, gray_levels)
+    calculate_gldm_coefficients(P_gldm::Matrix{Int},
+                                 gray_levels::Vector{Int})::Tuple{Float64, Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}}
 
     Calculates the coefficients used in the GLDM feature calculations.
 
@@ -176,7 +185,8 @@ end
     # Returns
     - A tuple containing the number of zones, sum over sizes, sum over gray levels, gray level vector, and size vector.
 """
-function calculate_gldm_coefficients(P_gldm, gray_levels)
+function calculate_gldm_coefficients(P_gldm::Matrix{Int},
+                                     gray_levels::Vector{Int})::Tuple{Float64, Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}}
     Nz = sum(P_gldm)
     Nz = Nz == 0 ? 1.0f-6 : Float64(Nz)
 
@@ -188,8 +198,8 @@ function calculate_gldm_coefficients(P_gldm, gray_levels)
     return Nz, pd, pg, ivector, jvector
 end
 
-# Feature implementations - optimized for vectorized operations
-function gldm_small_dependence_emphasis(pd, jvector, Nz)
+# Feature implementations
+function gldm_small_dependence_emphasis(pd::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for j in eachindex(jvector)
@@ -198,7 +208,7 @@ function gldm_small_dependence_emphasis(pd, jvector, Nz)
     return result * inv_Nz
 end
 
-function gldm_large_dependence_emphasis(pd, jvector, Nz)
+function gldm_large_dependence_emphasis(pd::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for j in eachindex(jvector)
@@ -207,7 +217,7 @@ function gldm_large_dependence_emphasis(pd, jvector, Nz)
     return result * inv_Nz
 end
 
-function gldm_gray_level_non_uniformity(pg, Nz)
+function gldm_gray_level_non_uniformity(pg::Vector{Float64}, Nz::Float64)::Float64
     sum_sq = 0.0
     @inbounds for val in pg
         sum_sq += val^2
@@ -215,7 +225,7 @@ function gldm_gray_level_non_uniformity(pg, Nz)
     return sum_sq / Nz
 end
 
-function gldm_dependence_non_uniformity(pd, Nz)
+function gldm_dependence_non_uniformity(pd::Vector{Float64}, Nz::Float64)::Float64
     sum_sq = 0.0
     @inbounds for val in pd
         sum_sq += val^2
@@ -223,7 +233,9 @@ function gldm_dependence_non_uniformity(pd, Nz)
     return sum_sq / Nz
 end
 
-gldm_dependence_non_uniformity_normalized(pd, Nz) = gldm_dependence_non_uniformity(pd, Nz) / Nz
+function gldm_dependence_non_uniformity_normalized(pd::Vector{Float64}, Nz::Float64)::Float64
+    return gldm_dependence_non_uniformity(pd, Nz) / Nz
+end
 
 """
     gldm_gray_level_variance(pg, ivector, Nz)
@@ -235,7 +247,7 @@ gldm_dependence_non_uniformity_normalized(pd, Nz) = gldm_dependence_non_uniformi
     # Returns
     - The calculated Gray Level Variance feature value.
 """
-function gldm_gray_level_variance(pg, ivector, Nz)
+function gldm_gray_level_variance(pg::Vector{Float64}, ivector::Vector{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     u_i = 0.0
     @inbounds for i in eachindex(ivector)
@@ -260,7 +272,7 @@ end
     - `Nz`: The number of zones.
     # Returns
     - The calculated Dependence Variance feature value."""
-function gldm_dependence_variance(pd, jvector, Nz)
+function gldm_dependence_variance(pd::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     u_j = 0.0
     @inbounds for j in eachindex(jvector)
@@ -285,7 +297,7 @@ end
     # Returns
     - The calculated Dependence Entropy feature value.
     """
-function gldm_dependence_entropy(P_gldm, Nz)
+function gldm_dependence_entropy(P_gldm::Matrix{Int}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     entropy = 0.0
     @inbounds for val in P_gldm
@@ -297,7 +309,7 @@ function gldm_dependence_entropy(P_gldm, Nz)
     return entropy
 end
 
-function gldm_low_gray_level_emphasis(pg, ivector, Nz)
+function gldm_low_gray_level_emphasis(pg::Vector{Float64}, ivector::Vector{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for i in eachindex(ivector)
@@ -306,7 +318,7 @@ function gldm_low_gray_level_emphasis(pg, ivector, Nz)
     return result * inv_Nz
 end
 
-function gldm_high_gray_level_emphasis(pg, ivector, Nz)
+function gldm_high_gray_level_emphasis(pg::Vector{Float64}, ivector::Vector{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for i in eachindex(ivector)
@@ -316,17 +328,16 @@ function gldm_high_gray_level_emphasis(pg, ivector, Nz)
 end
 
 """
-    gldm_small_dependence_low_gray_level_emphasis(P_gldm, ivector
-    , jvector, Nz)
+    gldm_small_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     Calculates the Small Dependence Low Gray Level Emphasis feature.
     # Arguments
     - `P_gldm`: The GLDM matrix.
-    - `ivector`: The gray level vector.
-    - `jvector`: The size vector.
+    - `i_sq`: The square of the gray level vector.
+    - `j_sq`: The square of the size vector.
     - `Nz`: The number of zones.
     # Returns
     - The calculated Small Dependence Low Gray Level Emphasis feature value."""
-function gldm_small_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
+function gldm_small_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
@@ -338,7 +349,7 @@ function gldm_small_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
 end
 
 """
-    gldm_small_dependence_high_gray_level_emphasis(P_gldm, ivector, jvector, Nz)
+    gldm_small_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     Calculates the Small Dependence High Gray Level Emphasis feature.
     # Arguments
     - `P_gldm`: The GLDM matrix.
@@ -347,7 +358,7 @@ end
     - `Nz`: The number of zones.
     # Returns
     - The calculated Small Dependence High Gray Level Emphasis feature value."""
-function gldm_small_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
+function gldm_small_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
@@ -359,7 +370,7 @@ function gldm_small_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
 end
 
 """
-    gldm_large_dependence_low_gray_level_emphasis(P_gldm, ivector, jvector, Nz)
+    gldm_large_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     Calculates the Large Dependence Low Gray Level Emphasis feature.
     # Arguments
     - `P_gldm`: The GLDM matrix.
@@ -369,7 +380,7 @@ end
     # Returns
     - The calculated Large Dependence Low Gray Level Emphasis feature value.   
     """
-function gldm_large_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
+function gldm_large_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
@@ -381,7 +392,7 @@ function gldm_large_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
 end
 
 """
-    gldm_large_dependence_high_gray_level_emphasis(P_gldm, ivector, jvector, Nz)
+    gldm_large_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     Calculates the Large Dependence High Gray Level Emphasis feature.
     # Arguments
     - `P_gldm`: The GLDM matrix.          
@@ -390,7 +401,7 @@ end
     - `Nz`: The number of zones.
     # Returns
     - The calculated Large Dependence High Gray Level Emphasis feature value."""
-function gldm_large_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
+function gldm_large_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
     inv_Nz = 1.0f0 / Nz
     result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)

--- a/src/gldm_features.jl
+++ b/src/gldm_features.jl
@@ -106,51 +106,79 @@ function calculate_gldm_matrix(discretized_img::Array{Int},
                                 mask::BitArray,
                                 gldm_a::Int,
                                 verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
-    if verbose
-        println("Calculating GLDM matrix...")
-    end
+    verbose && println("Calculating GLDM matrix...")
 
-    masked_img = discretized_img[mask]
+    masked_img  = discretized_img[mask]
     gray_levels = sort(unique(masked_img))
-    num_gl = length(gray_levels)
-    
-    gl_map = Dict{Int,Int}()
-    sizehint!(gl_map, num_gl)
+    num_gl      = length(gray_levels)
+
+    # Lookup on the Array instead of using a dictionary
+    min_gl = minimum(gray_levels)
+    max_gl = maximum(gray_levels)
+    gl_map = zeros(Int, max_gl - min_gl + 1)
     @inbounds for (i, gl) in enumerate(gray_levels)
-        gl_map[gl] = i
+        gl_map[gl - min_gl + 1] = i
     end
 
-    # Absolute maximum possible dependence size for 3D is 3^3 = 27
-    n_dims = ndims(discretized_img)
+    n_dims        = ndims(discretized_img)
     max_dependence = 3^n_dims
-    P_gldm = zeros(Int, num_gl, max_dependence)
+    P_gldm        = zeros(Int, num_gl, max_dependence)
 
-    neighbors_buffer = Vector{Int}(undef, max_dependence - 1)
-    img_size = size(discretized_img)
+    # Offsets CartesianIndex for the neighbors
+    offsets = [CartesianIndex(Tuple(o)) for o in Iterators.product((-1:1 for _ in 1:n_dims)...)
+               if !all(iszero, o)]
 
-    #Extracting flat linear indices (Int64) instead of CartesianIndex
-    masked_indices = findall(vec(mask))
+    sz           = size(discretized_img)
+    mask_indices = findall(mask)
 
-    @inbounds for i in masked_indices
-        gl = discretized_img[i]
-        gl_idx = gl_map[gl]
+    # Classification interior/border
+    interior_mask = eltype(mask_indices)[]
+    border_mask   = eltype(mask_indices)[]
+    sizehint!(interior_mask, length(mask_indices))
+    sizehint!(border_mask,   length(mask_indices))
 
-        dependence_count = 0
-        n_count = get_neighbors!(neighbors_buffer, i, img_size)
-        
-        for k in 1:n_count
-            neighbor_idx = neighbors_buffer[k]
-            if mask[neighbor_idx] && abs(gl - discretized_img[neighbor_idx]) <= gldm_a
+    for idx in mask_indices
+        t = Tuple(idx)
+        if all(t[k] > 1 && t[k] < sz[k] for k in 1:n_dims)
+            push!(interior_mask, idx)
+        else
+            push!(border_mask, idx)
+        end
+    end
+
+    # Interior: no checkbounds needed
+    @inbounds for idx in interior_mask
+        gl     = discretized_img[idx]
+        gl_idx = gl_map[gl - min_gl + 1]
+
+        dependence_count = 1  # center always dependent
+        for o in offsets
+            nidx = idx + o
+            if mask[nidx] && abs(gl - discretized_img[nidx]) <= gldm_a
                 dependence_count += 1
             end
         end
 
-        # Add center voxel (always dependent)
-        dependence_count += 1
         P_gldm[gl_idx, dependence_count] += 1
     end
 
-    # Trim trailing empty columns efficiently without high-allocation summing routines
+    # Border: checkbounds needed
+    for idx in border_mask
+        gl     = discretized_img[idx]
+        gl_idx = gl_map[gl - min_gl + 1]
+
+        dependence_count = 1
+        for o in offsets
+            nidx = idx + o
+            if checkbounds(Bool, discretized_img, nidx) && mask[nidx] && abs(gl - discretized_img[nidx]) <= gldm_a
+                dependence_count += 1
+            end
+        end
+
+        P_gldm[gl_idx, dependence_count] += 1
+    end
+
+    # Trim empty columns
     last_col = 0
     for j in size(P_gldm, 2):-1:1
         if any(!iszero, @view P_gldm[:, j])

--- a/src/gldm_features.jl
+++ b/src/gldm_features.jl
@@ -55,11 +55,6 @@ function get_gldm_features(img::AbstractArray{Float64},
 
     discretized_img, n_bins_actual, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
-    if verbose
-        println("Intensity Range: [$(minimum(img[mask])), $(maximum(img[mask]))]")
-        println("Effective Gray level utilized: $(n_bins_actual)")
-    end
-
     P_gldm, gray_levels = calculate_gldm_matrix(discretized_img, mask, gldm_a, verbose)
 
     if get_raw_matrices

--- a/src/gldm_features.jl
+++ b/src/gldm_features.jl
@@ -1,4 +1,3 @@
-
 using StatsBase
 
 """
@@ -75,31 +74,12 @@ function get_gldm_features(img::AbstractArray{Float64},
         return gldm_features
     end
 
-    Nz, pd, pg, ivector, jvector = calculate_gldm_coefficients(P_gldm, gray_levels)
-
-    # Pre-compute matrices for combined features to avoid redundant reshaping
-    i_mat = reshape(ivector, :, 1)
-    j_mat = reshape(jvector, 1, :)
-    i_sq = i_mat .^ 2
-    j_sq = j_mat .^ 2
-
-    gldm_features["gldm_SmallDependenceEmphasis"] = gldm_small_dependence_emphasis(pd, jvector, Nz)
-    gldm_features["gldm_LargeDependenceEmphasis"] = gldm_large_dependence_emphasis(pd, jvector, Nz)
-    gldm_features["gldm_GrayLevelNonUniformity"] = gldm_gray_level_non_uniformity(pg, Nz)
-    gldm_features["gldm_DependenceNonUniformity"] = gldm_dependence_non_uniformity(pd, Nz)
-    gldm_features["gldm_DependenceNonUniformityNormalized"] = gldm_dependence_non_uniformity_normalized(pd, Nz)
-    gldm_features["gldm_GrayLevelVariance"] = gldm_gray_level_variance(pg, ivector, Nz)
-    gldm_features["gldm_DependenceVariance"] = gldm_dependence_variance(pd, jvector, Nz)
-    gldm_features["gldm_DependenceEntropy"] = gldm_dependence_entropy(P_gldm, Nz)
-    gldm_features["gldm_LowGrayLevelEmphasis"] = gldm_low_gray_level_emphasis(pg, ivector, Nz)
-    gldm_features["gldm_HighGrayLevelEmphasis"] = gldm_high_gray_level_emphasis(pg, ivector, Nz)
-    gldm_features["gldm_SmallDependenceLowGrayLevelEmphasis"] = gldm_small_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
-    gldm_features["gldm_SmallDependenceHighGrayLevelEmphasis"] = gldm_small_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
-    gldm_features["gldm_LargeDependenceLowGrayLevelEmphasis"] = gldm_large_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
-    gldm_features["gldm_LargeDependenceHighGrayLevelEmphasis"] = gldm_large_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
+    # Extract all features in a unified pass
+    extracted_features = extract_all_gldm_features(P_gldm, gray_levels)
+    merge!(gldm_features, extracted_features)
 
     if verbose
-        println("Completed! Extract $(length(gldm_features)) features.")
+        println("Completed! Extracted $(length(gldm_features)) features.")
     end
 
     return gldm_features
@@ -133,281 +113,189 @@ function calculate_gldm_matrix(discretized_img::Array{Int},
     masked_img = discretized_img[mask]
     gray_levels = sort(unique(masked_img))
     num_gl = length(gray_levels)
-    gl_map = Dict(gl => i for (i, gl) in enumerate(gray_levels))
-
-    # Max dependence is 26 (neighbors) + 1 (center) = 27 for 3D
-    max_dependence = 27
-    P_gldm = zeros(Int, num_gl, max_dependence)
-
-    n_dims = ndims(discretized_img)
-    neighbors_buffer = Vector{Int}(undef, 3^n_dims - 1)
-
-    for i in eachindex(discretized_img)
-        if mask[i]
-            gl = discretized_img[i]
-            gl_idx = gl_map[gl]
-
-            dependence_count = 0
-
-            n_count = get_neighbors!(neighbors_buffer, i, size(discretized_img))
-            for k in 1:n_count
-                neighbor_idx = neighbors_buffer[k]
-                if mask[neighbor_idx] && abs(gl - discretized_img[neighbor_idx]) <= gldm_a
-                    dependence_count += 1
-                end
-            end
-
-            # Add center voxel (always dependent)
-            dependence_count += 1
-
-            P_gldm[gl_idx, dependence_count] += 1
-        end
+    
+    gl_map = Dict{Int,Int}()
+    sizehint!(gl_map, num_gl)
+    @inbounds for (i, gl) in enumerate(gray_levels)
+        gl_map[gl] = i
     end
 
-    # Trim empty columns
-    last_col = findlast(sum(P_gldm, dims=1) .> 0)
-    last_col = last_col === nothing ? 0 : last_col[2]
+    # Absolute maximum possible dependence size for 3D is 3^3 = 27
+    n_dims = ndims(discretized_img)
+    max_dependence = 3^n_dims
+    P_gldm = zeros(Int, num_gl, max_dependence)
+
+    neighbors_buffer = Vector{Int}(undef, max_dependence - 1)
+    img_size = size(discretized_img)
+
+    #Extracting flat linear indices (Int64) instead of CartesianIndex
+    masked_indices = findall(vec(mask))
+
+    @inbounds for i in masked_indices
+        gl = discretized_img[i]
+        gl_idx = gl_map[gl]
+
+        dependence_count = 0
+        n_count = get_neighbors!(neighbors_buffer, i, img_size)
+        
+        for k in 1:n_count
+            neighbor_idx = neighbors_buffer[k]
+            if mask[neighbor_idx] && abs(gl - discretized_img[neighbor_idx]) <= gldm_a
+                dependence_count += 1
+            end
+        end
+
+        # Add center voxel (always dependent)
+        dependence_count += 1
+        P_gldm[gl_idx, dependence_count] += 1
+    end
+
+    # Trim trailing empty columns efficiently without high-allocation summing routines
+    last_col = 0
+    for j in size(P_gldm, 2):-1:1
+        if any(!iszero, @view P_gldm[:, j])
+            last_col = j
+            break
+        end
+    end
     P_gldm = P_gldm[:, 1:last_col]
 
     return P_gldm, gray_levels
 end
 
 """
-    calculate_gldm_coefficients(P_gldm::Matrix{Int},
-                                 gray_levels::Vector{Int})::Tuple{Float64, Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}}
+    extract_all_gldm_features(P_gldm::Matrix{Int}, gray_levels::Vector{Int})::Dict{String, Any}
 
-    Calculates the coefficients used in the GLDM feature calculations.
-
-    # Arguments
-    - `P_gldm`: The GLDM matrix.
+    Arguments
+    - `P_gldm`: The Gray Level Dependence Matrix (GLDM).
     - `gray_levels`: The gray levels present in the ROI.
 
-    # Returns
-    - A tuple containing the number of zones, sum over sizes, sum over gray levels, gray level vector, and size vector.
+    Returns
+    - A dictionary where keys are the feature names and values are the calculated feature values.
+    
+    Performs a consolidated single-pass calculation over the matrix profile.
+    Replaces 14 disjoint feature functions to reduce iteration overhead and cache misses.
 """
-function calculate_gldm_coefficients(P_gldm::Matrix{Int},
-                                     gray_levels::Vector{Int})::Tuple{Float64, Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}}
+function extract_all_gldm_features(P_gldm::Matrix{Int}, gray_levels::Vector{Int})::Dict{String, Any}
     Nz = sum(P_gldm)
-    Nz = Nz == 0 ? 1.0f-6 : Float64(Nz)
+    Nz_scaled = Nz == 0 ? 1e-6 : Float64(Nz)
+    inv_Nz = 1.0 / Nz_scaled
+    inv_Nz_sq = inv_Nz * inv_Nz
 
+    num_gl = size(P_gldm, 1)
+    max_dep = size(P_gldm, 2)
+
+    # Clean 1D Vector definitions preventing multi-dimensional matrix layout allocations
+    ivector = Float64.(gray_levels)
+    jvector = Float64.(1:max_dep)
+    ivector_sq = ivector .^ 2
+    jvector_sq = jvector .^ 2
+
+    # Linear marginal sums
     pd = vec(sum(P_gldm, dims=1))
     pg = vec(sum(P_gldm, dims=2))
-    ivector = Float64.(gray_levels)
-    jvector = Float64.(1:size(P_gldm, 2))
 
-    return Nz, pd, pg, ivector, jvector
-end
+    # Initialize feature metric accumulators
+    f_SDE = 0.0
+    f_LDE = 0.0
+    f_GLNU = 0.0
+    f_DNU = 0.0
+    f_GLV = 0.0
+    f_DV = 0.0
+    f_DE = 0.0
+    f_LGLE = 0.0
+    f_HGLE = 0.0
+    f_SDLGLE = 0.0
+    f_SDHGLE = 0.0
+    f_LDLGLE = 0.0
+    f_LDHGLE = 0.0
 
-# Feature implementations
-function gldm_small_dependence_emphasis(pd::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for j in eachindex(jvector)
-        result += pd[j] / (jvector[j]^2)
-    end
-    return result * inv_Nz
-end
-
-function gldm_large_dependence_emphasis(pd::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for j in eachindex(jvector)
-        result += pd[j] * (jvector[j]^2)
-    end
-    return result * inv_Nz
-end
-
-function gldm_gray_level_non_uniformity(pg::Vector{Float64}, Nz::Float64)::Float64
-    sum_sq = 0.0
-    @inbounds for val in pg
-        sum_sq += val^2
-    end
-    return sum_sq / Nz
-end
-
-function gldm_dependence_non_uniformity(pd::Vector{Float64}, Nz::Float64)::Float64
-    sum_sq = 0.0
-    @inbounds for val in pd
-        sum_sq += val^2
-    end
-    return sum_sq / Nz
-end
-
-function gldm_dependence_non_uniformity_normalized(pd::Vector{Float64}, Nz::Float64)::Float64
-    return gldm_dependence_non_uniformity(pd, Nz) / Nz
-end
-
-"""
-    gldm_gray_level_variance(pg, ivector, Nz)
-    Calculates the Gray Level Variance feature.
-    # Arguments
-    - `pg`: The sum over gray levels vector.
-    - `ivector`: The gray level vector.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Gray Level Variance feature value.
-"""
-function gldm_gray_level_variance(pg::Vector{Float64}, ivector::Vector{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    u_i = 0.0
-    @inbounds for i in eachindex(ivector)
-        u_i += pg[i] * ivector[i]
-    end
-    u_i *= inv_Nz
-
-    variance = 0.0
-    @inbounds for i in eachindex(ivector)
-        diff = ivector[i] - u_i
-        variance += pg[i] * diff * diff
-    end
-    return variance * inv_Nz
-end
-
-"""
-    gldm_dependence_variance(pd, jvector, Nz)
-    Calculates the Dependence Variance feature.
-    # Arguments
-    - `pd`: The sum over sizes vector.
-    - `jvector`: The size vector.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Dependence Variance feature value."""
-function gldm_dependence_variance(pd::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    u_j = 0.0
-    @inbounds for j in eachindex(jvector)
-        u_j += pd[j] * jvector[j]
-    end
-    u_j *= inv_Nz
-
-    variance = 0.0
-    @inbounds for j in eachindex(jvector)
-        diff = jvector[j] - u_j
-        variance += pd[j] * diff * diff
-    end
-    return variance * inv_Nz
-end
-
-"""
-    gldm_dependence_entropy(P_gldm, Nz)
-    Calculates the Dependence Entropy feature.
-    # Arguments
-    - `P_gldm`: The GLDM matrix.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Dependence Entropy feature value.
-    """
-function gldm_dependence_entropy(P_gldm::Matrix{Int}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    entropy = 0.0
-    @inbounds for val in P_gldm
-        if val > 0
-            p = val * inv_Nz
-            entropy -= p * log2(p)
+    # 1D Row / Column Performance Blocks (Marginal dependence calculations)
+    u_j_sum = 0.0
+    @inbounds for j in 1:max_dep
+        val = Float64(pd[j])
+        if val > 0.0
+            j_sq = jvector_sq[j]
+            f_SDE += val / j_sq
+            f_LDE += val * j_sq
+            f_DNU += val^2
+            u_j_sum += val * jvector[j]
         end
     end
-    return entropy
-end
+    f_SDE *= inv_Nz
+    f_LDE *= inv_Nz
+    f_DNUN = (f_DNU * inv_Nz) * inv_Nz
+    f_DNU *= inv_Nz
+    u_j = u_j_sum * inv_Nz
 
-function gldm_low_gray_level_emphasis(pg::Vector{Float64}, ivector::Vector{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for i in eachindex(ivector)
-        result += pg[i] / (ivector[i]^2)
-    end
-    return result * inv_Nz
-end
-
-function gldm_high_gray_level_emphasis(pg::Vector{Float64}, ivector::Vector{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for i in eachindex(ivector)
-        result += pg[i] * (ivector[i]^2)
-    end
-    return result * inv_Nz
-end
-
-"""
-    gldm_small_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    Calculates the Small Dependence Low Gray Level Emphasis feature.
-    # Arguments
-    - `P_gldm`: The GLDM matrix.
-    - `i_sq`: The square of the gray level vector.
-    - `j_sq`: The square of the size vector.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Small Dependence Low Gray Level Emphasis feature value."""
-function gldm_small_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
-        if P_gldm[i, j] > 0
-            result += P_gldm[i, j] / (i_sq[i] * j_sq[j])
+    @inbounds for j in 1:max_dep
+        val = Float64(pd[j])
+        if val > 0.0
+            f_DV += val * (jvector[j] - u_j)^2
         end
     end
-    return result * inv_Nz
-end
+    f_DV *= inv_Nz
 
-"""
-    gldm_small_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    Calculates the Small Dependence High Gray Level Emphasis feature.
-    # Arguments
-    - `P_gldm`: The GLDM matrix.
-    - `ivector`: The gray level vector.
-    - `jvector`: The size vector.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Small Dependence High Gray Level Emphasis feature value."""
-function gldm_small_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
-        if P_gldm[i, j] > 0
-            result += P_gldm[i, j] * i_sq[i] / j_sq[j]
+    u_i_sum = 0.0
+    @inbounds for i in 1:num_gl
+        val = Float64(pg[i])
+        if val > 0.0
+            i_sq = ivector_sq[i]
+            f_GLNU += val^2
+            f_LGLE += val / i_sq
+            f_HGLE += val * i_sq
+            u_i_sum += val * ivector[i]
         end
     end
-    return result * inv_Nz
-end
+    f_GLNU *= inv_Nz
+    f_LGLE *= inv_Nz
+    f_HGLE *= inv_Nz
+    u_i = u_i_sum * inv_Nz
 
-"""
-    gldm_large_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    Calculates the Large Dependence Low Gray Level Emphasis feature.
-    # Arguments
-    - `P_gldm`: The GLDM matrix.
-    - `ivector`: The gray level vector.
-    - `jvector`: The size vector.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Large Dependence Low Gray Level Emphasis feature value.   
-    """
-function gldm_large_dependence_low_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
-        if P_gldm[i, j] > 0
-            result += P_gldm[i, j] * j_sq[j] / i_sq[i]
+    @inbounds for i in 1:num_gl
+        val = Float64(pg[i])
+        if val > 0.0
+            f_GLV += val * (ivector[i] - u_i)^2
         end
     end
-    return result * inv_Nz
-end
+    f_GLV *= inv_Nz
 
-"""
-    gldm_large_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    Calculates the Large Dependence High Gray Level Emphasis feature.
-    # Arguments
-    - `P_gldm`: The GLDM matrix.          
-    - `ivector`: The gray level vector.
-    - `jvector`: The size vector.
-    - `Nz`: The number of zones.
-    # Returns
-    - The calculated Large Dependence High Gray Level Emphasis feature value."""
-function gldm_large_dependence_high_gray_level_emphasis(P_gldm::Matrix{Int}, i_sq::Matrix{Float64}, j_sq::Matrix{Float64}, Nz::Float64)::Float64
-    inv_Nz = 1.0f0 / Nz
-    result = 0.0
-    @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
-        if P_gldm[i, j] > 0
-            result += P_gldm[i, j] * i_sq[i] * j_sq[j]
+    # Unified 2D loop running in Column-Major order (j outer, i inner) for maximum cache locality
+    @inbounds for j in 1:max_dep
+        j_sq = jvector_sq[j]
+        for i in 1:num_gl
+            val = Float64(P_gldm[i, j])
+            if val > 0.0
+                i_sq = ivector_sq[i]
+                p = val * inv_Nz
+                
+                f_DE -= p * log2(p)
+                f_SDLGLE += val / (i_sq * j_sq)
+                f_SDHGLE += val * i_sq / j_sq
+                f_LDLGLE += val * j_sq / i_sq
+                f_LDHGLE += val * i_sq * j_sq
+            end
         end
     end
-    return result * inv_Nz
+    f_SDLGLE *= inv_Nz
+    f_SDHGLE *= inv_Nz
+    f_LDLGLE *= inv_Nz
+    f_LDHGLE *= inv_Nz
+
+    return Dict{String, Any}(
+        "gldm_SmallDependenceEmphasis" => f_SDE,
+        "gldm_LargeDependenceEmphasis" => f_LDE,
+        "gldm_GrayLevelNonUniformity" => f_GLNU,
+        "gldm_DependenceNonUniformity" => f_DNU,
+        "gldm_DependenceNonUniformityNormalized" => f_DNUN,
+        "gldm_GrayLevelVariance" => f_GLV,
+        "gldm_DependenceVariance" => f_DV,
+        "gldm_DependenceEntropy" => f_DE,
+        "gldm_LowGrayLevelEmphasis" => f_LGLE,
+        "gldm_HighGrayLevelEmphasis" => f_HGLE,
+        "gldm_SmallDependenceLowGrayLevelEmphasis" => f_SDLGLE,
+        "gldm_SmallDependenceHighGrayLevelEmphasis" => f_SDHGLE,
+        "gldm_LargeDependenceLowGrayLevelEmphasis" => f_LDLGLE,
+        "gldm_LargeDependenceHighGrayLevelEmphasis" => f_LDHGLE
+    )
 end

--- a/src/gldm_features.jl
+++ b/src/gldm_features.jl
@@ -191,7 +191,7 @@ end
 # Feature implementations - optimized for vectorized operations
 function gldm_small_dependence_emphasis(pd, jvector, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for j in eachindex(jvector)
         result += pd[j] / (jvector[j]^2)
     end
@@ -200,7 +200,7 @@ end
 
 function gldm_large_dependence_emphasis(pd, jvector, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for j in eachindex(jvector)
         result += pd[j] * (jvector[j]^2)
     end
@@ -208,7 +208,7 @@ function gldm_large_dependence_emphasis(pd, jvector, Nz)
 end
 
 function gldm_gray_level_non_uniformity(pg, Nz)
-    sum_sq = 0.0f0
+    sum_sq = 0.0
     @inbounds for val in pg
         sum_sq += val^2
     end
@@ -216,7 +216,7 @@ function gldm_gray_level_non_uniformity(pg, Nz)
 end
 
 function gldm_dependence_non_uniformity(pd, Nz)
-    sum_sq = 0.0f0
+    sum_sq = 0.0
     @inbounds for val in pd
         sum_sq += val^2
     end
@@ -237,13 +237,13 @@ gldm_dependence_non_uniformity_normalized(pd, Nz) = gldm_dependence_non_uniformi
 """
 function gldm_gray_level_variance(pg, ivector, Nz)
     inv_Nz = 1.0f0 / Nz
-    u_i = 0.0f0
+    u_i = 0.0
     @inbounds for i in eachindex(ivector)
         u_i += pg[i] * ivector[i]
     end
     u_i *= inv_Nz
 
-    variance = 0.0f0
+    variance = 0.0
     @inbounds for i in eachindex(ivector)
         diff = ivector[i] - u_i
         variance += pg[i] * diff * diff
@@ -262,13 +262,13 @@ end
     - The calculated Dependence Variance feature value."""
 function gldm_dependence_variance(pd, jvector, Nz)
     inv_Nz = 1.0f0 / Nz
-    u_j = 0.0f0
+    u_j = 0.0
     @inbounds for j in eachindex(jvector)
         u_j += pd[j] * jvector[j]
     end
     u_j *= inv_Nz
 
-    variance = 0.0f0
+    variance = 0.0
     @inbounds for j in eachindex(jvector)
         diff = jvector[j] - u_j
         variance += pd[j] * diff * diff
@@ -287,7 +287,7 @@ end
     """
 function gldm_dependence_entropy(P_gldm, Nz)
     inv_Nz = 1.0f0 / Nz
-    entropy = 0.0f0
+    entropy = 0.0
     @inbounds for val in P_gldm
         if val > 0
             p = val * inv_Nz
@@ -299,7 +299,7 @@ end
 
 function gldm_low_gray_level_emphasis(pg, ivector, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for i in eachindex(ivector)
         result += pg[i] / (ivector[i]^2)
     end
@@ -308,7 +308,7 @@ end
 
 function gldm_high_gray_level_emphasis(pg, ivector, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for i in eachindex(ivector)
         result += pg[i] * (ivector[i]^2)
     end
@@ -328,7 +328,7 @@ end
     - The calculated Small Dependence Low Gray Level Emphasis feature value."""
 function gldm_small_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
         if P_gldm[i, j] > 0
             result += P_gldm[i, j] / (i_sq[i] * j_sq[j])
@@ -349,7 +349,7 @@ end
     - The calculated Small Dependence High Gray Level Emphasis feature value."""
 function gldm_small_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
         if P_gldm[i, j] > 0
             result += P_gldm[i, j] * i_sq[i] / j_sq[j]
@@ -371,7 +371,7 @@ end
     """
 function gldm_large_dependence_low_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
         if P_gldm[i, j] > 0
             result += P_gldm[i, j] * j_sq[j] / i_sq[i]
@@ -392,7 +392,7 @@ end
     - The calculated Large Dependence High Gray Level Emphasis feature value."""
 function gldm_large_dependence_high_gray_level_emphasis(P_gldm, i_sq, j_sq, Nz)
     inv_Nz = 1.0f0 / Nz
-    result = 0.0f0
+    result = 0.0
     @inbounds for j in axes(P_gldm, 2), i in axes(P_gldm, 1)
         if P_gldm[i, j] > 0
             result += P_gldm[i, j] * i_sq[i] * j_sq[j]

--- a/src/gldm_features.jl
+++ b/src/gldm_features.jl
@@ -178,12 +178,12 @@ end
 """
 function calculate_gldm_coefficients(P_gldm, gray_levels)
     Nz = sum(P_gldm)
-    Nz = Nz == 0 ? 1.0f-6 : Float32(Nz)
+    Nz = Nz == 0 ? 1.0f-6 : Float64(Nz)
 
     pd = vec(sum(P_gldm, dims=1))
     pg = vec(sum(P_gldm, dims=2))
-    ivector = Float32.(gray_levels)
-    jvector = Float32.(1:size(P_gldm, 2))
+    ivector = Float64.(gray_levels)
+    jvector = Float64.(1:size(P_gldm, 2))
 
     return Nz, pd, pg, ivector, jvector
 end

--- a/src/glrlm_features.jl
+++ b/src/glrlm_features.jl
@@ -146,7 +146,7 @@ function calculate_glrlm_matrix(discretized_img, mask, voxel_spacing, weighting_
     end
 
     num_angles = length(angles)
-    P_glrlm = zeros(Float32, num_gl, max_run_length, num_angles)
+    P_glrlm = zeros(Float64, num_gl, max_run_length, num_angles)
 
     cart_indices = CartesianIndices(size(discretized_img))
     lin_indices = LinearIndices(size(discretized_img))
@@ -188,9 +188,9 @@ function calculate_glrlm_matrix(discretized_img, mask, voxel_spacing, weighting_
 
     # Weighted sum in-place without allocating intermediate arrays
     if !isnothing(weighting_norm)
-        weights = ones(Float32, num_angles)
+        weights = ones(Float64, num_angles)
         @inbounds for (a_idx, angle) in enumerate(angles)
-            angle_vec = Float32.([angle...])
+            angle_vec = Float64.([angle...])
             current_spacing = voxel_spacing[1:dim]
             abs_angle_dist = abs.(angle_vec) .* current_spacing
             if weighting_norm == "infinity"
@@ -202,7 +202,7 @@ function calculate_glrlm_matrix(discretized_img, mask, voxel_spacing, weighting_
             end
         end
 
-        P_out = zeros(Float32, num_gl, max_run_length)
+        P_out = zeros(Float64, num_gl, max_run_length)
         @inbounds for a_idx in 1:num_angles
             @views P_out .+= weights[a_idx] .* P_glrlm[:, :, a_idx]
         end
@@ -230,17 +230,17 @@ function extract_all_glrlm_features(P_glrlm, gray_levels, feature_names)
     num_angles = size(P_glrlm, 3)
     max_run_length = size(P_glrlm, 2)
     num_features = length(feature_names)
-    feature_sums = zeros(Float32, num_features)
+    feature_sums = zeros(Float64, num_features)
 
-    ivector = Float32.(gray_levels)
-    jvector = Float32.(1:max_run_length)
+    ivector = Float64.(gray_levels)
+    jvector = Float64.(1:max_run_length)
     # Pre-compute squared vectors outside the loop (constant across angles)
     ivector_sq = ivector .^ 2
     jvector_sq = jvector .^ 2
 
     # Pre-allocate marginal sum buffers outside the loop to avoid repeated allocations
-    pr = zeros(Float32, 1, max_run_length)
-    pg = zeros(Float32, num_gl, 1)
+    pr = zeros(Float64, 1, max_run_length)
+    pg = zeros(Float64, num_gl, 1)
 
     @inbounds for i in 1:num_angles
         p_slice = @view P_glrlm[:, :, i]
@@ -249,7 +249,7 @@ function extract_all_glrlm_features(P_glrlm, gray_levels, feature_names)
             continue
         end
 
-        inv_Nr = 1.0f0 / Float32(Nr)
+        inv_Nr = 1.0f0 / Float64(Nr)
         inv_Nr_sq = inv_Nr * inv_Nr
 
         # In-place marginal sums: zero allocations
@@ -270,7 +270,7 @@ function extract_all_glrlm_features(P_glrlm, gray_levels, feature_names)
         feature_sums[6] += sum(pr[j]^2 for j in 1:max_run_length) * inv_Nr_sq
         # 7. RunPercentage
         Np = sum(pr[j] * jvector[j] for j in 1:max_run_length)
-        feature_sums[7] += Float32(Nr) / Np
+        feature_sums[7] += Float64(Nr) / Np
         # 8. GrayLevelVariance
         u_i = sum(pg[g] * ivector[g] for g in 1:num_gl) * inv_Nr
         feature_sums[8] += sum(pg[g] * inv_Nr * (ivector[g] - u_i)^2 for g in 1:num_gl)

--- a/src/glrlm_features.jl
+++ b/src/glrlm_features.jl
@@ -4,34 +4,6 @@ using StatsBase
     get_glrlm_features with weighting support
 
     Calculates and returns a dictionary of GLRLM (Gray Level Run Length Matrix) features.
-
-    You can specify EITHER n_bins (number of bins) OR bin_width (fixed bin width):
-    - If n_bins is specified, bin_width is calculated automatically from the intensity range
-    - If bin_width is specified, the number of bins depends on the intensity range
-    - If neither is specified, defaults to n_bins=32
-
-    # Arguments
-    - `img`: The input image.
-    - `mask`: The mask defining the region of interest.
-    - `voxel_spacing`: The spacing of the voxels in the image.
-    - `n_bins`: The number of bins for discretizing intensity values (optional).
-    - `bin_width`: The width of each bin (optional).
-    - `weighting_norm`: Weighting method ("infinity", "euclidean", "manhattan", "no_weighting", or nothing for no weighting)
-    - `get_raw_matrices`: If true, returns the raw GLRLM matrix.
-    - `verbose`: If true, prints progress messages.
-
-    # Returns
-    - A dictionary where keys are the feature names and values are the calculated feature values.
-
-    # Examples
-        # Using fixed number of bins with weighting
-        features = get_glrlm_features(img, mask, spacing, n_bins=64, weighting_norm="euclidean")
-        
-        # Using fixed bin width with weighting
-        features = get_glrlm_features(img, mask, spacing, bin_width=25.0f0, weighting_norm="infinity")
-        
-        # Default (32 bins, no weighting)
-        features = get_glrlm_features(img, mask, spacing)
 """
 function get_glrlm_features(img::AbstractArray{Float64},
                              mask::BitArray,
@@ -57,6 +29,7 @@ function get_glrlm_features(img::AbstractArray{Float64},
 
     glrlm_features = Dict{String,Any}()
 
+    # Assuming discretize_image is defined in utils.jl or globally available within the module
     discretized_img, n_bins_actual, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
     if verbose
@@ -92,30 +65,20 @@ function get_glrlm_features(img::AbstractArray{Float64},
     merge!(glrlm_features, extracted_features)
 
     if verbose
-        println("Completed! Extract $(length(glrlm_features)) features.")
+        println("Completed! Extracted $(length(glrlm_features)) features.")
     end
 
     return glrlm_features
 end
 
-"""
-    calculate_glrlm_matrix with weighting support
-
-    Calculates the Gray Level Run Length Matrix (GLRLM) with optional weighting.
-
-    # Arguments
-    - `discretized_img`: The discretized input image.
-    - `mask`: The mask defining the region of interest.
-    - `voxel_spacing`: The spacing of the voxels in the image.
-    - `weighting_norm`: Weighting method (nothing, "infinity", "euclidean", "manhattan", "no_weighting").
-    - `verbose`: If true, prints progress messages.
-
-    # Returns
-    - A tuple containing the GLRLM matrix and the angles used for calculation.
-"""
-
 const Angle = Union{Tuple{Int,Int}, Tuple{Int,Int,Int}}
 
+"""
+    calculate_glrlm_matrix
+
+    Calculates the GLRLM matrix. Tracks the real maximum run length 
+    dynamically to eliminate downstream computations on empty trailing columns.
+"""
 function calculate_glrlm_matrix(discretized_img::Array{Int},
                                  mask::BitArray,
                                  voxel_spacing::Vector{Float64},
@@ -137,7 +100,7 @@ function calculate_glrlm_matrix(discretized_img::Array{Int},
         gl_map[gl] = i
     end
 
-    max_run_length = maximum(size(discretized_img))
+    max_run_length_possible = maximum(size(discretized_img))
 
     if dim == 2
         angles = [
@@ -155,161 +118,187 @@ function calculate_glrlm_matrix(discretized_img::Array{Int},
     end
 
     num_angles = length(angles)
-    P_glrlm = zeros(Float64, num_gl, max_run_length, num_angles)
+    P_glrlm = zeros(Float64, num_gl, max_run_length_possible, num_angles)
 
     cart_indices = CartesianIndices(size(discretized_img))
-    lin_indices = LinearIndices(size(discretized_img))
-
-    # Pre-compute CartesianIndex for each angle
     c_angles = [CartesianIndex(a) for a in angles]
-
-    # Iterate only over masked voxels instead of the entire image
     masked_cart_indices = cart_indices[mask]
+
+    # Track the actual maximum run length to scale down the feature extraction phase
+    actual_max_run = 1
 
     @inbounds for (angle_idx, c_angle) in enumerate(c_angles)
         for curr_idx_cart in masked_cart_indices
-            i = lin_indices[curr_idx_cart]
-            gl = discretized_img[i]
+            gl = discretized_img[curr_idx_cart]
             gl_idx = gl_map[gl]
 
-            # Skip if this voxel is not the start of a run
+            # Check if this voxel is the start of a run
             prev_idx_cart = curr_idx_cart - c_angle
             if checkbounds(Bool, discretized_img, prev_idx_cart)
-                prev_idx = lin_indices[prev_idx_cart]
-                if mask[prev_idx] && discretized_img[prev_idx] == gl
+                # Direct indexing using CartesianIndex bypasses LinearIndices overhead
+                if mask[prev_idx_cart] && discretized_img[prev_idx_cart] == gl
                     continue
                 end
             end
 
-            # Count run length
+            # Count run length along current direction vector
             run_length = 1
             next_idx_cart = curr_idx_cart + c_angle
             while checkbounds(Bool, discretized_img, next_idx_cart) &&
-                  mask[lin_indices[next_idx_cart]] &&
+                  mask[next_idx_cart] &&
                   discretized_img[next_idx_cart] == gl
                 run_length += 1
                 next_idx_cart += c_angle
             end
 
-            P_glrlm[gl_idx, run_length, angle_idx] += 1.0f0
+            P_glrlm[gl_idx, run_length, angle_idx] += 1.0
+            if run_length > actual_max_run
+                actual_max_run = run_length
+            end
         end
     end
 
-    # Weighted sum in-place without allocating intermediate arrays
+    # Crop the matrix to the actual maximum run length found
+    P_glrlm = P_glrlm[:, 1:actual_max_run, :]
+
     if !isnothing(weighting_norm)
         weights = ones(Float64, num_angles)
         @inbounds for (a_idx, angle) in enumerate(angles)
-            angle_vec = Float64.([angle...])
-            current_spacing = voxel_spacing[1:dim]
-            abs_angle_dist = abs.(angle_vec) .* current_spacing
+            # Tuple unpacking prevents unnecessary heap allocations
+            if dim == 2
+                dists = (abs(angle[1]) * voxel_spacing[1], abs(angle[2]) * voxel_spacing[2])
+            else
+                dists = (abs(angle[1]) * voxel_spacing[1], abs(angle[2]) * voxel_spacing[2], abs(angle[3]) * voxel_spacing[3])
+            end
+            
             if weighting_norm == "infinity"
-                weights[a_idx] = maximum(abs_angle_dist)
+                weights[a_idx] = max(dists...)
             elseif weighting_norm == "euclidean"
-                weights[a_idx] = sqrt(sum(abs_angle_dist .^ 2))
+                weights[a_idx] = sqrt(sum(x -> x^2, dists))
             elseif weighting_norm == "manhattan"
-                weights[a_idx] = sum(abs_angle_dist)
+                weights[a_idx] = sum(dists)
             end
         end
 
-        P_out = zeros(Float64, num_gl, max_run_length)
+        P_out = zeros(Float64, num_gl, actual_max_run)
         @inbounds for a_idx in 1:num_angles
             @views P_out .+= weights[a_idx] .* P_glrlm[:, :, a_idx]
         end
-        return reshape(P_out, num_gl, max_run_length, 1), angles
+        return reshape(P_out, num_gl, actual_max_run, 1), angles
     end
 
     return P_glrlm, angles
 end
 
 """
-    extract_all_glrlm_features(P_glrlm, gray_levels, feature_names)
+    extract_all_glrlm_features
 
-    Calculates all GLRLM features in a single pass to avoid redundant computations.
-
-    # Arguments
-    - `P_glrlm`: The GLRLM matrix.
-    - `gray_levels`: The gray levels used.
-    - `feature_names`: The list of feature names to extract.
-
-    # Returns
-    - A dictionary containing all calculated feature values.
+    Extracts all features via a high-performance single-pass, flat 2D loop.
+    Skips empty rows/columns and eliminates nested generator heap allocations.
 """
 function extract_all_glrlm_features(P_glrlm::Array{Float64,3},
                                      gray_levels::Vector{Int},
                                      feature_names::Vector{String})::Dict{String,Any}
     num_gl = length(gray_levels)
-    num_angles = size(P_glrlm, 3)
     max_run_length = size(P_glrlm, 2)
+    num_angles = size(P_glrlm, 3)
     num_features = length(feature_names)
+    
     feature_sums = zeros(Float64, num_features)
 
     ivector = Float64.(gray_levels)
     jvector = Float64.(1:max_run_length)
-    # Pre-compute squared vectors outside the loop (constant across angles)
     ivector_sq = ivector .^ 2
     jvector_sq = jvector .^ 2
 
-    # Pre-allocate marginal sum buffers outside the loop to avoid repeated allocations
     pr = zeros(Float64, 1, max_run_length)
     pg = zeros(Float64, num_gl, 1)
 
-    @inbounds for i in 1:num_angles
-        p_slice = @view P_glrlm[:, :, i]
+    @inbounds for a in 1:num_angles
+        p_slice = @view P_glrlm[:, :, a]
         Nr = sum(p_slice)
-        if Nr == 0
+        if Nr == 0.0
             continue
         end
 
-        inv_Nr = 1.0f0 / Float64(Nr)
+        inv_Nr = 1.0 / Nr
         inv_Nr_sq = inv_Nr * inv_Nr
 
-        # In-place marginal sums: zero allocations
         sum!(pr, p_slice)
         sum!(pg, p_slice)
 
-        # 1. ShortRunEmphasis
-        feature_sums[1] += sum(pr[j] / jvector_sq[j] for j in 1:max_run_length) * inv_Nr
-        # 2. LongRunEmphasis
-        feature_sums[2] += sum(pr[j] * jvector_sq[j] for j in 1:max_run_length) * inv_Nr
-        # 3. GrayLevelNonUniformity
-        feature_sums[3] += sum(pg[g]^2 for g in 1:num_gl) * inv_Nr
-        # 4. GrayLevelNonUniformityNormalized
-        feature_sums[4] += sum(pg[g]^2 for g in 1:num_gl) * inv_Nr_sq
-        # 5. RunLengthNonUniformity
-        feature_sums[5] += sum(pr[j]^2 for j in 1:max_run_length) * inv_Nr
-        # 6. RunLengthNonUniformityNormalized
-        feature_sums[6] += sum(pr[j]^2 for j in 1:max_run_length) * inv_Nr_sq
-        # 7. RunPercentage
-        Np = sum(pr[j] * jvector[j] for j in 1:max_run_length)
-        feature_sums[7] += Float64(Nr) / Np
-        # 8. GrayLevelVariance
-        u_i = sum(pg[g] * ivector[g] for g in 1:num_gl) * inv_Nr
-        feature_sums[8] += sum(pg[g] * inv_Nr * (ivector[g] - u_i)^2 for g in 1:num_gl)
-        # 9. RunVariance
-        u_j = sum(pr[j] * jvector[j] for j in 1:max_run_length) * inv_Nr
-        feature_sums[9] += sum(pr[j] * inv_Nr * (jvector[j] - u_j)^2 for j in 1:max_run_length)
-        # 10. RunEntropy
-        feature_sums[10] += -sum(p_slice[g,j] * inv_Nr * log2(p_slice[g,j] * inv_Nr + 1.0f-16)
-                                  for g in 1:num_gl, j in 1:max_run_length)
-        # 11. LowGrayLevelRunEmphasis
-        feature_sums[11] += sum(pg[g] / ivector_sq[g] for g in 1:num_gl) * inv_Nr
-        # 12. HighGrayLevelRunEmphasis
-        feature_sums[12] += sum(pg[g] * ivector_sq[g] for g in 1:num_gl) * inv_Nr
-        # 13. ShortRunLowGrayLevelEmphasis
-        feature_sums[13] += sum(p_slice[g,j] / (ivector_sq[g] * jvector_sq[j])
-                                 for g in 1:num_gl, j in 1:max_run_length) * inv_Nr
-        # 14. ShortRunHighGrayLevelEmphasis
-        feature_sums[14] += sum(p_slice[g,j] * ivector_sq[g] / jvector_sq[j]
-                                 for g in 1:num_gl, j in 1:max_run_length) * inv_Nr
-        # 15. LongRunLowGrayLevelEmphasis
-        feature_sums[15] += sum(p_slice[g,j] * jvector_sq[j] / ivector_sq[g]
-                                 for g in 1:num_gl, j in 1:max_run_length) * inv_Nr
-        # 16. LongRunHighGrayLevelEmphasis
-        feature_sums[16] += sum(p_slice[g,j] * ivector_sq[g] * jvector_sq[j]
-                                 for g in 1:num_gl, j in 1:max_run_length) * inv_Nr
+        # 1D Vector Optimization: Run Length metrics (j-dependent)
+        Np = 0.0
+        u_j_sum = 0.0
+        for j in 1:max_run_length
+            if pr[j] > 0.0
+                j_sq = jvector_sq[j]
+                pr_j = pr[j]
+                
+                feature_sums[1] += (pr_j / j_sq) * inv_Nr               # ShortRunEmphasis
+                feature_sums[2] += (pr_j * j_sq) * inv_Nr               # LongRunEmphasis
+                feature_sums[5] += (pr_j^2) * inv_Nr                    # RunLengthNonUniformity
+                feature_sums[6] += (pr_j^2) * inv_Nr_sq                 # RunLengthNonUniformityNormalized
+                
+                Np += pr_j * jvector[j]
+                u_j_sum += pr_j * jvector[j]
+            end
+        end
+        
+        if Np > 0.0
+            feature_sums[7] += Nr / Np                                  # RunPercentage
+        end
+
+        # 1D Vector Optimization: Gray Level metrics (g-dependent)
+        u_i_sum = 0.0
+        for g in 1:num_gl
+            if pg[g] > 0.0
+                i_sq = ivector_sq[g]
+                pg_g = pg[g]
+                
+                feature_sums[3] += (pg_g^2) * inv_Nr                    # GrayLevelNonUniformity
+                feature_sums[4] += (pg_g^2) * inv_Nr_sq                 # GrayLevelNonUniformityNormalized
+                feature_sums[11] += (pg_g / i_sq) * inv_Nr              # LowGrayLevelRunEmphasis
+                feature_sums[12] += (pg_g * i_sq) * inv_Nr              # HighGrayLevelRunEmphasis
+                
+                u_i_sum += pg_g * ivector[g]
+            end
+        end
+
+        # Variance profiles 
+        u_j = u_j_sum * inv_Nr
+        u_i = u_i_sum * inv_Nr
+        for j in 1:max_run_length
+            if pr[j] > 0.0
+                feature_sums[9] += pr[j] * inv_Nr * (jvector[j] - u_j)^2 # RunVariance
+            end
+        end
+        for g in 1:num_gl
+            if pg[g] > 0.0
+                feature_sums[8] += pg[g] * inv_Nr * (ivector[g] - u_i)^2 # GrayLevelVariance
+            end
+        end
+
+        # Unified 2D loop over non-zero values (Column-major iteration for cache locality)
+        for j in 1:max_run_length
+            j_sq = jvector_sq[j]
+            for g in 1:num_gl
+                p_val = p_slice[g,j]
+                if p_val > 0.0
+                    i_sq = ivector_sq[g]
+                    prob = p_val * inv_Nr
+                    
+                    feature_sums[10] += -prob * log2(prob + 1e-16)              # RunEntropy
+                    feature_sums[13] += (p_val / (i_sq * j_sq)) * inv_Nr        # ShortRunLowGrayLevelEmphasis
+                    feature_sums[14] += (p_val * i_sq / j_sq) * inv_Nr          # ShortRunHighGrayLevelEmphasis
+                    feature_sums[15] += (p_val * j_sq / i_sq) * inv_Nr          # LongRunLowGrayLevelEmphasis
+                    feature_sums[16] += (p_val * i_sq * j_sq) * inv_Nr          # LongRunHighGrayLevelEmphasis
+                end
+            end
+        end
     end
 
-    inv_angles = 1.0f0 / num_angles
+    inv_angles = 1.0 / num_angles
     glrlm_features = Dict{String,Any}()
     for (idx, name) in enumerate(feature_names)
         glrlm_features["glrlm_"*name] = feature_sums[idx] * inv_angles

--- a/src/glrlm_features.jl
+++ b/src/glrlm_features.jl
@@ -32,11 +32,6 @@ function get_glrlm_features(img::AbstractArray{Float64},
     # Assuming discretize_image is defined in utils.jl or globally available within the module
     discretized_img, n_bins_actual, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
-    if verbose
-        println("Intensity Range: [$(minimum(img[mask])), $(maximum(img[mask]))]")
-        println("Effective Gray level utilized: $(n_bins_actual)")
-    end
-
     P_glrlm, angles = calculate_glrlm_matrix(discretized_img, mask, voxel_spacing, weighting_norm, verbose)
 
     if get_raw_matrices

--- a/src/glrlm_features.jl
+++ b/src/glrlm_features.jl
@@ -33,12 +33,14 @@ using StatsBase
         # Default (32 bins, no weighting)
         features = get_glrlm_features(img, mask, spacing)
 """
-function get_glrlm_features(img, mask, voxel_spacing;
-    n_bins::Union{Int,Nothing}=nothing,
-    bin_width::Union{Float64,Nothing}=nothing,
-    weighting_norm::Union{String,Nothing}=nothing,
-    get_raw_matrices::Bool=false,
-    verbose=false)
+function get_glrlm_features(img::AbstractArray{Float64},
+                             mask::BitArray,
+                             voxel_spacing::Vector{Float64};
+                             n_bins::Union{Int,Nothing}=nothing,
+                             bin_width::Union{Float64,Nothing}=nothing,
+                             weighting_norm::Union{String,Nothing}=nothing,
+                             get_raw_matrices::Bool=false,
+                             verbose::Bool=false)::Dict{String,Any}
     
     if verbose
         if !isnothing(n_bins)
@@ -111,7 +113,14 @@ end
     # Returns
     - A tuple containing the GLRLM matrix and the angles used for calculation.
 """
-function calculate_glrlm_matrix(discretized_img, mask, voxel_spacing, weighting_norm, verbose)
+
+const Angle = Union{Tuple{Int,Int}, Tuple{Int,Int,Int}}
+
+function calculate_glrlm_matrix(discretized_img::Array{Int},
+                                 mask::BitArray,
+                                 voxel_spacing::Vector{Float64},
+                                 weighting_norm::Union{String,Nothing},
+                                 verbose::Bool)::Tuple{Array{Float64,3}, Vector{Angle}}
     if verbose
         println("Calculating GLRLM matrix...")
     end
@@ -225,7 +234,9 @@ end
     # Returns
     - A dictionary containing all calculated feature values.
 """
-function extract_all_glrlm_features(P_glrlm, gray_levels, feature_names)
+function extract_all_glrlm_features(P_glrlm::Array{Float64,3},
+                                     gray_levels::Vector{Int},
+                                     feature_names::Vector{String})::Dict{String,Any}
     num_gl = length(gray_levels)
     num_angles = size(P_glrlm, 3)
     max_run_length = size(P_glrlm, 2)

--- a/src/glszm_features.jl
+++ b/src/glszm_features.jl
@@ -121,44 +121,58 @@ function calculate_glszm_matrix(discretized_img::Array{Int},
                                  mask::BitArray,
                                  verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
 
-    if verbose
-        println("Calculating GLSZM matrix...")
+    verbose && println("Calculating GLSZM matrix...")
+
+    sz     = size(discretized_img)
+    n_dims = ndims(discretized_img)
+
+    masked_img  = discretized_img[mask]
+    gray_levels = sort(unique(masked_img))
+    num_gl      = length(gray_levels)
+
+    # Lookup array invece di Dict
+    min_gl = minimum(gray_levels)
+    max_gl = maximum(gray_levels)
+    gl_map = zeros(Int, max_gl - min_gl + 1)
+    @inbounds for (i, gl) in enumerate(gray_levels)
+        gl_map[gl - min_gl + 1] = i
     end
 
-    sz = size(discretized_img)
-    n_dims = ndims(discretized_img)
-    masked_img = discretized_img[mask]
-    gray_levels = sort(unique(masked_img))
-    num_gl = length(gray_levels)
-    gl_map = Dict(gl => i for (i, gl) in enumerate(gray_levels))
-
-    visited = falses(sz)
+    visited       = falses(sz)
     max_mask_size = count(mask)
-    bfs_queue = Vector{Int}(undef, max_mask_size)
-    neighbors_buffer = Vector{Int}(undef, 3^n_dims - 1)
+    bfs_queue     = Vector{Int}(undef, max_mask_size)
+
+    # Offsets CartesianIndex per i vicini (come GLCM)
+    offsets = [CartesianIndex(Tuple(o)) for o in Iterators.product((-1:1 for _ in 1:n_dims)...)
+               if !all(iszero, o)]
+
+    cart_indices   = CartesianIndices(sz)
+    linear_indices = LinearIndices(sz)
 
     zone_counts = Dict{Tuple{Int,Int}, Int}()
 
-    for i in eachindex(discretized_img)
+    @inbounds for i in eachindex(discretized_img)
         if mask[i] && !visited[i]
-            gl = discretized_img[i]
-            gl_idx = gl_map[gl]
+            gl     = discretized_img[i]
+            gl_idx = gl_map[gl - min_gl + 1]
 
             bfs_queue[1] = i
-            visited[i] = true
+            visited[i]   = true
             head = 1
             tail = 1
 
             while head <= tail
-                curr_idx = bfs_queue[head]
-                head += 1
+                curr_idx      = bfs_queue[head]
+                curr_cart     = cart_indices[curr_idx]
+                head         += 1
 
-                n_count = get_neighbors!(neighbors_buffer, curr_idx, sz)
-                for k in 1:n_count
-                    nb = neighbors_buffer[k]
+                for o in offsets
+                    nb_cart = curr_cart + o
+                    checkbounds(Bool, discretized_img, nb_cart) || continue
+                    nb = linear_indices[nb_cart]
                     if mask[nb] && !visited[nb] && discretized_img[nb] == gl
-                        visited[nb] = true
-                        tail += 1
+                        visited[nb]  = true
+                        tail        += 1
                         bfs_queue[tail] = nb
                     end
                 end
@@ -172,7 +186,7 @@ function calculate_glszm_matrix(discretized_img::Array{Int},
 
     isempty(zone_counts) && return zeros(Int, num_gl, 1), gray_levels
 
-    max_zone_size = maximum(j for ((_,j), _) in zone_counts)  
+    max_zone_size = maximum(j for ((_, j), _) in zone_counts)
     P_glszm = zeros(Int, num_gl, max_zone_size)
     for ((gl_idx, zone_size), cnt) in zone_counts
         P_glszm[gl_idx, zone_size] += cnt
@@ -234,9 +248,18 @@ zone_percentage(Nz::Float64, Np::Float64)::Float64 = Nz / Np
     - The calculated Gray Level Variance value.
     """
 function gray_level_variance(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Float64)::Float64
-    p_g = pg ./ Nz
-    u_i = sum(p_g .* ivector)
-    sum(p_g .* (ivector .- u_i) .^ 2)
+    inv_Nz = 1.0 / Nz
+    u_i = 0.0
+    @inbounds for i in eachindex(ivector)
+        u_i += pg[i] * ivector[i]
+    end
+    u_i *= inv_Nz
+    result = 0.0
+    @inbounds for i in eachindex(ivector)
+        diff = ivector[i] - u_i
+        result += pg[i] * diff * diff
+    end
+    return result * inv_Nz
 end
 
 """
@@ -250,9 +273,18 @@ end
     - The calculated Zone Variance value.
     """
 function zone_variance(ps::Matrix{Int}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    p_s = ps' ./ Nz
-    u_j = sum(p_s .* jvector)
-    sum(p_s .* (jvector .- u_j) .^ 2)
+    inv_Nz = 1.0 / Nz
+    u_j = 0.0
+    @inbounds for j in eachindex(jvector)
+        u_j += ps[j] * jvector[j]
+    end
+    u_j *= inv_Nz
+    result = 0.0
+    @inbounds for j in eachindex(jvector)
+        diff = jvector[j] - u_j
+        result += ps[j] * diff * diff
+    end
+    return result * inv_Nz
 end
 
 """
@@ -265,8 +297,14 @@ end
     - The calculated Zone Entropy value.
     """
 function zone_entropy(P_glszm::Matrix{Int}, Nz::Float64)::Float64
-    p_glszm = P_glszm ./ Nz
-    -sum(p_glszm .* log2.(p_glszm .+ 1.0e-16))
+    inv_Nz = 1.0 / Nz
+    result = 0.0
+    @inbounds for v in P_glszm
+        v == 0 && continue
+        p = v * inv_Nz
+        result -= p * log2(p + 1.0e-16)
+    end
+    return result
 end
 
 low_gray_level_zone_emphasis(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Float64)::Float64 = sum(pg ./ (ivector .^ 2)) / Nz
@@ -283,9 +321,13 @@ high_gray_level_zone_emphasis(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Flo
     - The calculated Small Area Low Gray Level Emphasis value.
     """
 function small_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    i_mat = reshape(ivector, :, 1)
-    j_mat = reshape(jvector, 1, :)
-    sum(P_glszm ./ ((i_mat .^ 2) .* (j_mat .^ 2))) / Nz
+    result = 0.0
+    @inbounds for j in axes(P_glszm, 2), i in axes(P_glszm, 1)
+        v = P_glszm[i, j]
+        v == 0 && continue
+        result += v / (ivector[i]^2 * jvector[j]^2)
+    end
+    return result / Nz
 end
 
 """small_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
@@ -299,9 +341,13 @@ end
     - The calculated Small Area High Gray Level Emphasis value.
     """
 function small_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    i_mat = reshape(ivector, :, 1)
-    j_mat = reshape(jvector, 1, :)
-    sum(P_glszm .* (i_mat .^ 2) ./ (j_mat .^ 2)) / Nz
+    result = 0.0
+    @inbounds for j in axes(P_glszm, 2), i in axes(P_glszm, 1)
+        v = P_glszm[i, j]
+        v == 0 && continue
+        result += v * ivector[i]^2 / jvector[j]^2
+    end
+    return result / Nz
 end
 
 """large_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
@@ -315,9 +361,13 @@ end
     - The calculated Large Area Low Gray Level Emphasis value.
     """
 function large_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    i_mat = reshape(ivector, :, 1)
-    j_mat = reshape(jvector, 1, :)
-    sum(P_glszm .* (j_mat .^ 2) ./ (i_mat .^ 2)) / Nz
+    result = 0.0
+    @inbounds for j in axes(P_glszm, 2), i in axes(P_glszm, 1)
+        v = P_glszm[i, j]
+        v == 0 && continue
+        result += v * jvector[j]^2 / ivector[i]^2
+    end
+    return result / Nz
 end
 
 """large_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
@@ -331,7 +381,11 @@ end
     - The calculated Large Area High Gray Level Emphasis value.
     """
 function large_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
-    i_mat = reshape(ivector, :, 1)
-    j_mat = reshape(jvector, 1, :)
-    sum(P_glszm .* (i_mat .^ 2) .* (j_mat .^ 2)) / Nz
+    result = 0.0
+    @inbounds for j in axes(P_glszm, 2), i in axes(P_glszm, 1)
+        v = P_glszm[i, j]
+        v == 0 && continue
+        result += v * ivector[i]^2 * jvector[j]^2
+    end
+    return result / Nz
 end

--- a/src/glszm_features.jl
+++ b/src/glszm_features.jl
@@ -32,11 +32,13 @@ using StatsBase
         # Default (32 bins)
         features = get_glszm_features(img, mask, spacing)
     """
-function get_glszm_features(img, mask, voxel_spacing; 
-                           n_bins::Union{Int,Nothing}=nothing,
-                           bin_width::Union{Float64,Nothing}=nothing,
-                           get_raw_matrices::Bool=false,
-                           verbose=false)
+function get_glszm_features(img::AbstractArray{Float64},
+                             mask::BitArray,
+                             voxel_spacing::Vector{Float64};
+                             n_bins::Union{Int,Nothing}=nothing,
+                             bin_width::Union{Float64,Nothing}=nothing,
+                             get_raw_matrices::Bool=false,
+                             verbose::Bool=false)::Dict{String,Any}
     if verbose
         if !isnothing(n_bins)
             println("GLSZM calculation with $(n_bins) bins...")
@@ -101,7 +103,9 @@ function get_glszm_features(img, mask, voxel_spacing;
 end
 
 """
-    calculate_glszm_matrix(discretized_img, mask, verbose)
+    calculate_glszm_matrix(discretized_img::Array{Int},
+                             mask::BitArray,
+                             verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
 
     Calculates the Gray Level Size Zone Matrix (GLSZM).
 
@@ -113,7 +117,9 @@ end
     # Returns
     - A tuple containing the GLSZM matrix and the gray levels present in the ROI.
     """
-function calculate_glszm_matrix(discretized_img, mask, verbose)
+function calculate_glszm_matrix(discretized_img::Array{Int},
+                                 mask::BitArray,
+                                 verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
     if verbose
         println("Calculating GLSZM matrix...")
     end
@@ -184,7 +190,13 @@ end
     # Returns
     - A tuple containing the number of voxels, number of zones, sum over gray levels, sum over sizes, gray level vector, and size vector.
     """
-function calculate_glszm_coefficients(P_glszm, gray_levels)
+function calculate_glszm_coefficients(P_glszm::Matrix{Int},
+                                      gray_levels::Vector{Int})::Tuple{Float64,
+                                                                     Float64,
+                                                                     Matrix{Int},
+                                                                     Matrix{Int},
+                                                                     Vector{Float64},
+                                                                     Vector{Float64}}
     ps = sum(P_glszm, dims=1)
     pg = sum(P_glszm, dims=2)
     ivector = Float64.(gray_levels)
@@ -199,17 +211,17 @@ function calculate_glszm_coefficients(P_glszm, gray_levels)
     return Np, Nz, ps, pg, ivector, jvector
 end
 
-# Feature implementations
-small_area_emphasis(ps, jvector, Nz) = sum(ps' ./ (jvector .^ 2)) / Nz
-large_area_emphasis(ps, jvector, Nz) = sum(ps' .* (jvector .^ 2)) / Nz
-gray_level_non_uniformity(pg, Nz) = sum(pg .^ 2) / Nz
-gray_level_non_uniformity_normalized(pg, Nz) = sum(pg .^ 2) / (Nz ^ 2)
-size_zone_non_uniformity(ps, Nz) = sum(ps .^ 2) / Nz
-size_zone_non_uniformity_normalized(ps, Nz) = sum(ps .^ 2) / (Nz ^ 2)
-zone_percentage(Nz, Np) = Nz / Np
+# One-liners features implementations
+small_area_emphasis(ps::Matrix{Int}, jvector::Vector{Float64}, Nz::Float64)::Float64 = sum(ps' ./ (jvector .^ 2)) / Nz
+large_area_emphasis(ps::Matrix{Int}, jvector::Vector{Float64}, Nz::Float64)::Float64 = sum(ps' .* (jvector .^ 2)) / Nz
+gray_level_non_uniformity(pg::Matrix{Int}, Nz::Float64)::Float64 = sum(pg .^ 2) / Nz
+gray_level_non_uniformity_normalized(pg::Matrix{Int}, Nz::Float64)::Float64 = sum(pg .^ 2) / (Nz ^ 2)
+size_zone_non_uniformity(ps::Matrix{Int}, Nz::Float64)::Float64 = sum(ps .^ 2) / Nz
+size_zone_non_uniformity_normalized(ps::Matrix{Int}, Nz::Float64)::Float64 = sum(ps .^ 2) / (Nz ^ 2)
+zone_percentage(Nz::Float64, Np::Float64)::Float64 = Nz / Np
 
 """
-    gray_level_variance(pg, ivector, Nz)
+    gray_level_variance(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Float64)::Float64
     Calculates the Gray Level Variance feature.
     # Arguments
     - `pg`: Sum over gray levels.
@@ -218,14 +230,14 @@ zone_percentage(Nz, Np) = Nz / Np
     # Returns
     - The calculated Gray Level Variance value.
     """
-function gray_level_variance(pg, ivector, Nz)
+function gray_level_variance(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Float64)::Float64
     p_g = pg ./ Nz
     u_i = sum(p_g .* ivector)
     sum(p_g .* (ivector .- u_i) .^ 2)
 end
 
 """
-    zone_variance(ps, jvector, Nz)
+    zone_variance(ps::Matrix{Int}, jvector::Vector{Float64}, Nz::Float64)::Float64
     Calculates the Zone Variance feature.
     # Arguments
     - `ps`: Sum over sizes.  
@@ -234,14 +246,14 @@ end
     # Returns
     - The calculated Zone Variance value.
     """
-function zone_variance(ps, jvector, Nz)
+function zone_variance(ps::Matrix{Int}, jvector::Vector{Float64}, Nz::Float64)::Float64
     p_s = ps' ./ Nz
     u_j = sum(p_s .* jvector)
     sum(p_s .* (jvector .- u_j) .^ 2)
 end
 
 """
-    zone_entropy(P_glszm, Nz)
+    zone_entropy(P_glszm::Matrix{Int}, Nz::Float64)::Float64
     Calculates the Zone Entropy feature.
     # Arguments
     - `P_glszm`: The GLSZM matrix.
@@ -249,15 +261,15 @@ end
     # Returns
     - The calculated Zone Entropy value.
     """
-function zone_entropy(P_glszm, Nz)
+function zone_entropy(P_glszm::Matrix{Int}, Nz::Float64)::Float64
     p_glszm = P_glszm ./ Nz
-    -sum(p_glszm .* log2.(p_glszm .+ 1.0f-16))
+    -sum(p_glszm .* log2.(p_glszm .+ 1.0e-16))
 end
 
-low_gray_level_zone_emphasis(pg, ivector, Nz) = sum(pg ./ (ivector .^ 2)) / Nz
-high_gray_level_zone_emphasis(pg, ivector, Nz) = sum(pg .* (ivector .^ 2)) / Nz
+low_gray_level_zone_emphasis(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Float64)::Float64 = sum(pg ./ (ivector .^ 2)) / Nz
+high_gray_level_zone_emphasis(pg::Matrix{Int}, ivector::Vector{Float64}, Nz::Float64)::Float64 = sum(pg .* (ivector .^ 2)) / Nz
 
-"""small_area_low_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+"""small_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     Calculates the Small Area Low Gray Level Emphasis feature.
     # Arguments
     - `P_glszm`: The GLSZM matrix.
@@ -267,13 +279,13 @@ high_gray_level_zone_emphasis(pg, ivector, Nz) = sum(pg .* (ivector .^ 2)) / Nz
     # Returns
     - The calculated Small Area Low Gray Level Emphasis value.
     """
-function small_area_low_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+function small_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     i_mat = reshape(ivector, :, 1)
     j_mat = reshape(jvector, 1, :)
     sum(P_glszm ./ ((i_mat .^ 2) .* (j_mat .^ 2))) / Nz
 end
 
-"""small_area_high_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+"""small_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     Calculates the Small Area High Gray Level Emphasis feature.
     # Arguments
     - `P_glszm`: The GLSZM matrix.
@@ -283,13 +295,13 @@ end
     # Returns
     - The calculated Small Area High Gray Level Emphasis value.
     """
-function small_area_high_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+function small_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     i_mat = reshape(ivector, :, 1)
     j_mat = reshape(jvector, 1, :)
     sum(P_glszm .* (i_mat .^ 2) ./ (j_mat .^ 2)) / Nz
 end
 
-"""large_area_low_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+"""large_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     Calculates the Large Area Low Gray Level Emphasis feature.
     # Arguments
     - `P_glszm`: The GLSZM matrix.
@@ -299,13 +311,13 @@ end
     # Returns
     - The calculated Large Area Low Gray Level Emphasis value.
     """
-function large_area_low_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+function large_area_low_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     i_mat = reshape(ivector, :, 1)
     j_mat = reshape(jvector, 1, :)
     sum(P_glszm .* (j_mat .^ 2) ./ (i_mat .^ 2)) / Nz
 end
 
-"""large_area_high_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+"""large_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     Calculates the Large Area High Gray Level Emphasis feature.
     # Arguments
     - `P_glszm`: The GLSZM matrix.
@@ -315,7 +327,7 @@ end
     # Returns
     - The calculated Large Area High Gray Level Emphasis value.
     """
-function large_area_high_gray_level_emphasis(P_glszm, ivector, jvector, Nz)
+function large_area_high_gray_level_emphasis(P_glszm::Matrix{Int}, ivector::Vector{Float64}, jvector::Vector{Float64}, Nz::Float64)::Float64
     i_mat = reshape(ivector, :, 1)
     j_mat = reshape(jvector, 1, :)
     sum(P_glszm .* (i_mat .^ 2) .* (j_mat .^ 2)) / Nz

--- a/src/glszm_features.jl
+++ b/src/glszm_features.jl
@@ -187,8 +187,8 @@ end
 function calculate_glszm_coefficients(P_glszm, gray_levels)
     ps = sum(P_glszm, dims=1)
     pg = sum(P_glszm, dims=2)
-    ivector = Float32.(gray_levels)
-    jvector = Float32.(1:size(P_glszm, 2))
+    ivector = Float64.(gray_levels)
+    jvector = Float64.(1:size(P_glszm, 2))
 
     Nz = sum(P_glszm)
     Nz = Nz == 0 ? 1.0f-6 : Nz

--- a/src/glszm_features.jl
+++ b/src/glszm_features.jl
@@ -54,11 +54,6 @@ function get_glszm_features(img::AbstractArray{Float64},
     # 1. Discretize the image
     discretized_img, n_bins_actual, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
-    if verbose
-        println("Intensity Range: [$(minimum(img[mask])), $(maximum(img[mask]))]")
-        println("Effective Gray level utilized: $(n_bins_actual)")
-    end
-
     # 2. Calculate the GLSZM matrix
     P_glszm, gray_levels = calculate_glszm_matrix(discretized_img, mask, verbose)
 

--- a/src/glszm_features.jl
+++ b/src/glszm_features.jl
@@ -120,60 +120,63 @@ end
 function calculate_glszm_matrix(discretized_img::Array{Int},
                                  mask::BitArray,
                                  verbose::Bool)::Tuple{Matrix{Int}, Vector{Int}}
+
     if verbose
         println("Calculating GLSZM matrix...")
     end
 
+    sz = size(discretized_img)
+    n_dims = ndims(discretized_img)
     masked_img = discretized_img[mask]
-    min_gl = minimum(masked_img)
-    max_gl = maximum(masked_img)
     gray_levels = sort(unique(masked_img))
     num_gl = length(gray_levels)
     gl_map = Dict(gl => i for (i, gl) in enumerate(gray_levels))
 
-    max_size = count(mask)
-    P_glszm = zeros(Int, num_gl, max_size)
-
-    visited = falses(size(discretized_img))
-
-    n_dims = ndims(discretized_img)
+    visited = falses(sz)
+    max_mask_size = count(mask)
+    bfs_queue = Vector{Int}(undef, max_mask_size)
     neighbors_buffer = Vector{Int}(undef, 3^n_dims - 1)
+
+    zone_counts = Dict{Tuple{Int,Int}, Int}()
 
     for i in eachindex(discretized_img)
         if mask[i] && !visited[i]
             gl = discretized_img[i]
             gl_idx = gl_map[gl]
 
-            zone_size = 0
-            q = [i]
+            bfs_queue[1] = i
             visited[i] = true
-
             head = 1
-            while head <= length(q)
-                curr_idx = q[head]
-                head += 1
-                zone_size += 1
+            tail = 1
 
-                n_count = get_neighbors!(neighbors_buffer, curr_idx, size(discretized_img))
+            while head <= tail
+                curr_idx = bfs_queue[head]
+                head += 1
+
+                n_count = get_neighbors!(neighbors_buffer, curr_idx, sz)
                 for k in 1:n_count
-                    neighbor_idx = neighbors_buffer[k]
-                    if mask[neighbor_idx] && !visited[neighbor_idx] && discretized_img[neighbor_idx] == gl
-                        visited[neighbor_idx] = true
-                        push!(q, neighbor_idx)
+                    nb = neighbors_buffer[k]
+                    if mask[nb] && !visited[nb] && discretized_img[nb] == gl
+                        visited[nb] = true
+                        tail += 1
+                        bfs_queue[tail] = nb
                     end
                 end
             end
 
-            if zone_size > 0
-                P_glszm[gl_idx, zone_size] += 1
-            end
+            zone_size = tail
+            key = (gl_idx, zone_size)
+            zone_counts[key] = get(zone_counts, key, 0) + 1
         end
     end
 
-    # Trim empty columns
-    last_col = findlast(sum(P_glszm, dims=1) .> 0)
-    last_col = last_col === nothing ? 0 : last_col[2]
-    P_glszm = P_glszm[:, 1:last_col]
+    isempty(zone_counts) && return zeros(Int, num_gl, 1), gray_levels
+
+    max_zone_size = maximum(j for ((_,j), _) in zone_counts)  
+    P_glszm = zeros(Int, num_gl, max_zone_size)
+    for ((gl_idx, zone_size), cnt) in zone_counts
+        P_glszm[gl_idx, zone_size] += cnt
+    end
 
     return P_glszm, gray_levels
 end

--- a/src/ngtdm_features.jl
+++ b/src/ngtdm_features.jl
@@ -32,11 +32,13 @@ using StatsBase
         # Default (32 bins)
         features = get_ngtdm_features(img, mask, spacing)
     """
-function get_ngtdm_features(img, mask, voxel_spacing; 
-                           n_bins::Union{Int,Nothing}=nothing,
-                           bin_width::Union{Float64,Nothing}=nothing,
-                           get_raw_matrices::Bool=false,
-                           verbose=false)
+function get_ngtdm_features(img::AbstractArray{Float64},
+                             mask::BitArray,
+                             voxel_spacing::Vector{Float64};
+                             n_bins::Union{Int,Nothing}=nothing,
+                             bin_width::Union{Float64,Nothing}=nothing,
+                             get_raw_matrices::Bool=false,
+                             verbose::Bool=false)::Dict{String,Any}
     if verbose
         if !isnothing(n_bins)
             println("NGTDM calculation with $(n_bins) bins...")
@@ -102,7 +104,10 @@ end
     # Returns
     - A tuple containing the NGTDM matrix and the gray levels present in the ROI.
     """
-function calculate_ngtdm_matrix(discretized_img, mask, verbose)
+function calculate_ngtdm_matrix(discretized_img::Array{Int},
+                                 mask::BitArray,
+                                 verbose::Bool)::Tuple{Matrix{Float64}, Vector{Int}}
+
     if verbose
         println("Calculating NGTDM matrix...")
     end
@@ -147,8 +152,8 @@ function calculate_ngtdm_matrix(discretized_img, mask, verbose)
 end
 
 """
-    calculate_ngtdm_coefficients(P_ngtdm, gray_levels)
-
+    calculate_ngtdm_coefficients(P_ngtdm::Matrix{Float64},
+                                 gray_levels::Vector{Int})::Tuple{Float64,Vector{Float64},Vector{Float64},Vector{Float64},Int}
     Calculates the coefficients used in the NGTDM feature calculations.
 
     # Arguments
@@ -158,7 +163,8 @@ end
     # Returns
     - A tuple containing the number of voxels with a valid region, the gray level probability vector, the sum of absolute differences vector, the gray level vector, and the number of gray levels for which `p_i` > 0.
     """
-function calculate_ngtdm_coefficients(P_ngtdm, gray_levels)
+function calculate_ngtdm_coefficients(P_ngtdm::Matrix{Float64},
+                                      gray_levels::Vector{Int})::Tuple{Float64,Vector{Float64},Vector{Float64},Vector{Float64},Int}
     Nvp = sum(P_ngtdm[:, 1])
     p_i = P_ngtdm[:, 1] ./ Nvp
     s_i = P_ngtdm[:, 2]
@@ -169,19 +175,23 @@ function calculate_ngtdm_coefficients(P_ngtdm, gray_levels)
 end
 
 """
-    coarseness(p_i, s_i)
+    coarseness(p_i::Vector{Float64}, s_i::Vector{Float64})::Float64
     Calculates the Coarseness feature.
     """
-function coarseness(p_i, s_i)
+function coarseness(p_i::Vector{Float64}, s_i::Vector{Float64})::Float64
     sum_coarse = sum(p_i .* s_i)
     return sum_coarse == 0 ? 1e6 : 1 / sum_coarse
 end
 
 """
-    contrast(p_i, s_i, i, Ngp, Nvp)
+    contrast(p_i::Vector{Float64}, s_i::Vector{Float64}, i::Vector{Float64}, Ngp::Int, Nvp::Float64)::Float64
     Calculates the Contrast feature.
     """
-function contrast(p_i, s_i, i, Ngp, Nvp)
+function contrast(p_i::Vector{Float64},
+                  s_i::Vector{Float64},
+                  i::Vector{Float64},
+                  Ngp::Int,
+                  Nvp::Float64)::Float64
     if Ngp <= 1
         return 0.0
     end
@@ -194,10 +204,12 @@ function contrast(p_i, s_i, i, Ngp, Nvp)
 end
 
 """
-    busyness(p_i, s_i, i)
+    busyness(p_i::Vector{Float64}, s_i::Vector{Float64}, i::Vector{Float64})::Float64
     Calculates the Busyness feature.
     """
-function busyness(p_i, s_i, i)
+function busyness(p_i::Vector{Float64},
+                  s_i::Vector{Float64},
+                  i::Vector{Float64})::Float64
     p_zero_mask = p_i .== 0
     i_pi = i .* p_i
 
@@ -215,10 +227,13 @@ function busyness(p_i, s_i, i)
 end
 
 """
-    complexity(p_i, s_i, i, Nvp)
+    complexity(p_i::Vector{Float64}, s_i::Vector{Float64}, i::Vector{Float64}, Nvp::Float64)::Float64
     Calculates the Complexity feature.
     """
-function complexity(p_i, s_i, i, Nvp)
+function complexity(p_i::Vector{Float64},
+                  s_i::Vector{Float64},
+                  i::Vector{Float64},
+                  Nvp::Float64)::Float64
     p_zero_mask = p_i .== 0
     pi_si = p_i .* s_i
 
@@ -234,10 +249,12 @@ function complexity(p_i, s_i, i, Nvp)
 end
 
 """
-    strength(p_i, s_i, i)
+    strength(p_i::Vector{Float64}, s_i::Vector{Float64}, i::Vector{Float64})::Float64
     Calculates the Strength feature.
     """
-function strength(p_i, s_i, i)
+function strength(p_i::Vector{Float64},
+                  s_i::Vector{Float64},
+                  i::Vector{Float64})::Float64
     sum_s_i = sum(s_i)
     if sum_s_i == 0
         return 0.0

--- a/src/ngtdm_features.jl
+++ b/src/ngtdm_features.jl
@@ -108,43 +108,88 @@ function calculate_ngtdm_matrix(discretized_img::Array{Int},
                                  mask::BitArray,
                                  verbose::Bool)::Tuple{Matrix{Float64}, Vector{Int}}
 
-    if verbose
-        println("Calculating NGTDM matrix...")
-    end
+    verbose && println("Calculating NGTDM matrix...")
 
-    masked_img = discretized_img[mask]
+    masked_img  = discretized_img[mask]
     gray_levels = sort(unique(masked_img))
-    num_gl = length(gray_levels)
-    gl_map = Dict(gl => i for (i, gl) in enumerate(gray_levels))
+    num_gl      = length(gray_levels)
+
+    # Lookup array invece di Dict
+    min_gl = minimum(gray_levels)
+    max_gl = maximum(gray_levels)
+    gl_map = zeros(Int, max_gl - min_gl + 1)
+    @inbounds for (i, gl) in enumerate(gray_levels)
+        gl_map[gl - min_gl + 1] = i
+    end
 
     P_ngtdm = zeros(Float64, num_gl, 3)
 
-    n_dims = ndims(discretized_img)
-    neighbors_buffer = Vector{Int}(undef, 3^n_dims - 1)
+    n_dims  = ndims(discretized_img)
+    offsets = [CartesianIndex(Tuple(o)) for o in Iterators.product((-1:1 for _ in 1:n_dims)...)
+               if !all(iszero, o)]
 
-    for i in eachindex(discretized_img)
-        if mask[i]
-            gl = discretized_img[i]
-            gl_idx = gl_map[gl]
+    sz            = size(discretized_img)
+    cart_indices  = CartesianIndices(sz)
+    linear_indices = LinearIndices(sz)
 
-            neighborhood_sum = 0
-            neighborhood_count = 0
+    mask_indices  = findall(mask)
+    interior_mask = eltype(mask_indices)[]
+    border_mask   = eltype(mask_indices)[]
+    sizehint!(interior_mask, length(mask_indices))
+    sizehint!(border_mask,   length(mask_indices))
 
-            n_count = get_neighbors!(neighbors_buffer, i, size(discretized_img))
-            for k in 1:n_count
-                neighbor_idx = neighbors_buffer[k]
-                if mask[neighbor_idx]
-                    neighborhood_sum += discretized_img[neighbor_idx]
-                    neighborhood_count += 1
-                end
+    for idx in mask_indices
+        t = Tuple(idx)
+        if all(t[k] > 1 && t[k] < sz[k] for k in 1:n_dims)
+            push!(interior_mask, idx)
+        else
+            push!(border_mask, idx)
+        end
+    end
+
+    @inbounds for idx in interior_mask
+        gl     = discretized_img[idx]
+        gl_idx = gl_map[gl - min_gl + 1]
+
+        neighborhood_sum   = 0
+        neighborhood_count = 0
+
+        for o in offsets
+            nidx = idx + o
+            if mask[nidx]
+                neighborhood_sum   += discretized_img[nidx]
+                neighborhood_count += 1
             end
+        end
 
-            if neighborhood_count > 0
-                neighborhood_avg = neighborhood_sum / neighborhood_count
-                P_ngtdm[gl_idx, 1] += 1
-                P_ngtdm[gl_idx, 2] += abs(gl - neighborhood_avg)
-                P_ngtdm[gl_idx, 3] = gl
+        if neighborhood_count > 0
+            neighborhood_avg    = neighborhood_sum / neighborhood_count
+            P_ngtdm[gl_idx, 1] += 1
+            P_ngtdm[gl_idx, 2] += abs(gl - neighborhood_avg)
+            P_ngtdm[gl_idx, 3]  = gl
+        end
+    end
+
+    for idx in border_mask
+        gl     = discretized_img[idx]
+        gl_idx = gl_map[gl - min_gl + 1]
+
+        neighborhood_sum   = 0
+        neighborhood_count = 0
+
+        for o in offsets
+            nidx = idx + o
+            if checkbounds(Bool, discretized_img, nidx) && mask[nidx]
+                neighborhood_sum   += discretized_img[nidx]
+                neighborhood_count += 1
             end
+        end
+
+        if neighborhood_count > 0
+            neighborhood_avg    = neighborhood_sum / neighborhood_count
+            P_ngtdm[gl_idx, 1] += 1
+            P_ngtdm[gl_idx, 2] += abs(gl - neighborhood_avg)
+            P_ngtdm[gl_idx, 3]  = gl
         end
     end
 
@@ -192,15 +237,13 @@ function contrast(p_i::Vector{Float64},
                   i::Vector{Float64},
                   Ngp::Int,
                   Nvp::Float64)::Float64
-    if Ngp <= 1
-        return 0.0
+    Ngp <= 1 && return 0.0
+    n = length(p_i)
+    val = 0.0
+    @inbounds for a in 1:n, b in 1:n
+        val += p_i[a] * p_i[b] * (i[a] - i[b])^2
     end
-
-    div = Ngp * (Ngp - 1)
-
-    contrast_val = (sum(p_i' .* p_i .* (i' .- i) .^ 2) * sum(s_i) / Nvp)
-
-    return contrast_val / div
+    return val * sum(s_i) / Nvp / (Ngp * (Ngp - 1))
 end
 
 """
@@ -210,20 +253,20 @@ end
 function busyness(p_i::Vector{Float64},
                   s_i::Vector{Float64},
                   i::Vector{Float64})::Float64
-    p_zero_mask = p_i .== 0
-    i_pi = i .* p_i
-
-    abs_diff = abs.(i_pi' .- i_pi)
-    abs_diff[p_zero_mask, :] .= 0
-    abs_diff[:, p_zero_mask] .= 0
-
-    sum_abs_diff = sum(abs_diff)
-
-    if sum_abs_diff == 0
-        return 0.0
+    n = length(p_i)
+    num = 0.0
+    den = 0.0
+    @inbounds for k in 1:n
+        num += p_i[k] * s_i[k]
     end
-
-    return sum(p_i .* s_i) / sum_abs_diff
+    @inbounds for a in 1:n
+        p_i[a] == 0 && continue
+        for b in 1:n
+            p_i[b] == 0 && continue
+            den += abs(i[a] * p_i[a] - i[b] * p_i[b])
+        end
+    end
+    return den == 0 ? 0.0 : num / den
 end
 
 """
@@ -231,21 +274,20 @@ end
     Calculates the Complexity feature.
     """
 function complexity(p_i::Vector{Float64},
-                  s_i::Vector{Float64},
-                  i::Vector{Float64},
-                  Nvp::Float64)::Float64
-    p_zero_mask = p_i .== 0
-    pi_si = p_i .* s_i
-
-    numerator = pi_si' .+ pi_si
-    numerator[p_zero_mask, :] .= 0
-    numerator[:, p_zero_mask] .= 0
-
-    divisor = p_i' .+ p_i
-    divisor[divisor .== 0] .= 1 # Avoid division by zero
-
-    complexity_val = sum(abs.(i' .- i) .* numerator ./ divisor) / Nvp
-    return complexity_val
+                    s_i::Vector{Float64},
+                    i::Vector{Float64},
+                    Nvp::Float64)::Float64
+    n = length(p_i)
+    val = 0.0
+    @inbounds for a in 1:n
+        p_i[a] == 0 && continue
+        for b in 1:n
+            p_i[b] == 0 && continue
+            denom = p_i[a] + p_i[b]
+            val += abs(i[a] - i[b]) * (p_i[a] * s_i[a] + p_i[b] * s_i[b]) / denom
+        end
+    end
+    return val / Nvp
 end
 
 """
@@ -256,14 +298,15 @@ function strength(p_i::Vector{Float64},
                   s_i::Vector{Float64},
                   i::Vector{Float64})::Float64
     sum_s_i = sum(s_i)
-    if sum_s_i == 0
-        return 0.0
+    sum_s_i == 0 && return 0.0
+    n = length(p_i)
+    val = 0.0
+    @inbounds for a in 1:n
+        p_i[a] == 0 && continue
+        for b in 1:n
+            p_i[b] == 0 && continue
+            val += (p_i[a] + p_i[b]) * (i[a] - i[b])^2
+        end
     end
-
-    p_zero_mask = p_i .== 0
-    strength_val = (p_i' .+ p_i) .* (i' .- i) .^ 2
-    strength_val[p_zero_mask, :] .= 0
-    strength_val[:, p_zero_mask] .= 0
-
-    return sum(strength_val) / sum_s_i
+    return val / sum_s_i
 end

--- a/src/ngtdm_features.jl
+++ b/src/ngtdm_features.jl
@@ -112,7 +112,7 @@ function calculate_ngtdm_matrix(discretized_img, mask, verbose)
     num_gl = length(gray_levels)
     gl_map = Dict(gl => i for (i, gl) in enumerate(gray_levels))
 
-    P_ngtdm = zeros(Float32, num_gl, 3)
+    P_ngtdm = zeros(Float64, num_gl, 3)
 
     n_dims = ndims(discretized_img)
     neighbors_buffer = Vector{Int}(undef, 3^n_dims - 1)
@@ -162,7 +162,7 @@ function calculate_ngtdm_coefficients(P_ngtdm, gray_levels)
     Nvp = sum(P_ngtdm[:, 1])
     p_i = P_ngtdm[:, 1] ./ Nvp
     s_i = P_ngtdm[:, 2]
-    ivector = Float32.(gray_levels)
+    ivector = Float64.(gray_levels)
     Ngp = sum(P_ngtdm[:, 1] .> 0)
 
     return Nvp, p_i, s_i, ivector, Ngp

--- a/src/ngtdm_features.jl
+++ b/src/ngtdm_features.jl
@@ -54,11 +54,6 @@ function get_ngtdm_features(img::AbstractArray{Float64},
     # 1. Discretize the image
     discretized_img, n_bins_actual, gray_levels, bin_width_used = discretize_image(img, mask; n_bins=n_bins, bin_width=bin_width)
 
-    if verbose
-        println("Intensity Range: [$(minimum(img[mask])), $(maximum(img[mask]))]")
-        println("Effective gray level: $(n_bins_actual)")
-    end
-
     # 2. Calculate the NGTDM matrix
     P_ngtdm, gray_levels = calculate_ngtdm_matrix(discretized_img, mask, verbose)
 

--- a/src/shape_2D_features.jl
+++ b/src/shape_2D_features.jl
@@ -1,5 +1,33 @@
 using LinearAlgebra
 
+# Global constants — allocated once at module load, not at every function call
+const LINE_TABLE_2D = NTuple{5,Int8}[
+    (-1, -1, -1, -1, -1),
+    ( 3,  0, -1, -1, -1),
+    ( 0,  1, -1, -1, -1),
+    ( 3,  1, -1, -1, -1),
+    ( 1,  2, -1, -1, -1),
+    ( 1,  2,  3,  0, -1),
+    ( 0,  2, -1, -1, -1),
+    ( 3,  2, -1, -1, -1),
+    ( 2,  3, -1, -1, -1),
+    ( 2,  0, -1, -1, -1),
+    ( 0,  1,  2,  3, -1),
+    ( 2,  1, -1, -1, -1),
+    ( 1,  3, -1, -1, -1),
+    ( 1,  0, -1, -1, -1),
+    ( 0,  3, -1, -1, -1),
+    (-1, -1, -1, -1, -1),
+]
+
+const VERT_LIST_2D = NTuple{2,Float64}[
+    (0.0, 0.5), (0.5, 1.0), (1.0, 0.5), (0.5, 0.0)
+]
+
+const GRID_ANGLES_2D = ((0,0), (0,1), (1,1), (1,0))
+
+const POINTS_EDGES_2D = ((0, 2), (3, 2))
+
 """
     Extract 2D shape features from a binary mask.   
     # Arguments
@@ -76,7 +104,7 @@ end
     - Float64 representing the perimeter to surface ratio.
     """
 function get_perimeter_surface_ratio(perimeter::Float64, surface::Float64)::Float64
-    return Float64(perimeter / surface)
+    return perimeter / surface
 end
 
 """Calculate the sphericity of a 2D shape.
@@ -88,7 +116,7 @@ end
     - Float64 representing the sphericity of the shape.
     """
 function get_sphericity(perimeter::Float64, surface::Float64)::Float64
-    return Float64((2 * sqrt(pi * surface)) / perimeter)
+    return (2 * sqrt(pi * surface)) / perimeter
 end
 
 """Calculate the eigenvalues of the covariance matrix of the shape's voxel coordinates.
@@ -99,35 +127,35 @@ end
     - Vector of Float64 containing the eigenvalues sorted in ascending order.
     """
 function get_eigenvalues(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float64})::Vector{Float64}
-    coords = Iterators.filter(i -> mask[i], CartesianIndices(mask))
-    Np = count(_ -> true, coords)
+    Np = count(mask)
+    Np == 0 && return zeros(Float64, 2)
 
-    if Np == 0
-        return zeros(Float64, 2)
+    xs = Vector{Float64}(undef, Np)
+    ys = Vector{Float64}(undef, Np)
+    k  = 1
+    @inbounds for I in CartesianIndices(mask)
+        if mask[I]
+            xs[k] = (I[1] - 1) * spacing[1]
+            ys[k] = (I[2] - 1) * spacing[2]
+            k += 1
+        end
     end
 
-    offset_x = (0:size(mask, 1)-1) .* spacing[1]
-    offset_y = (0:size(mask, 2)-1) .* spacing[2]
+    meanx = sum(xs) / Np
+    meany = sum(ys) / Np
 
-    points = [(offset_x[c[1]], offset_y[c[2]]) for c in coords]
-
-    if isempty(points)
-        return zeros(Float64, 2)
+    c11 = c12 = c22 = 0.0
+    @inbounds for i in 1:Np
+        dx = xs[i] - meanx
+        dy = ys[i] - meany
+        c11 += dx * dx
+        c12 += dx * dy
+        c22 += dy * dy
     end
+    c11 /= Np; c12 /= Np; c22 /= Np
 
-    xs = Float64[x for (x, _) in points]
-    ys = Float64[y for (_, y) in points]
-
-    meanx = mean(xs)
-    meany = mean(ys)
-
-    centered = hcat(xs .- meanx, ys .- meany)
-
-    covmat = centered' * centered / Np
-
-    eigvals = eigen(covmat).values
-
-    return Float64.(sort(eigvals, rev=false))
+    ev = eigen(Symmetric([c11 c12; c12 c22])).values
+    return Float64.(sort(ev, rev=false))
 end
 
 """Calculate the pixel surface area of the shape represented by the binary mask.
@@ -138,7 +166,7 @@ end
     - Float64 representing the pixel surface area of the shape.
     """
 function get_pixel_surface(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float64})::Float64
-    return Float64(count(mask) * (spacing[1] * spacing[2]))
+    return Float64(count(mask)) * spacing[1] * spacing[2]
 end
 
 """
@@ -147,7 +175,7 @@ end
     This is a measure of the size of the shape in the direction of its major axis.
     """
 function get_major_axis_length(ev::Vector{Float64})::Float64
-    return ev[2] >= 0 ? Float64(4*sqrt(ev[2])) : NaN
+    return ev[2] >= 0 ? 4.0 * sqrt(ev[2]) : NaN
 end
 
 """
@@ -156,7 +184,7 @@ end
     This is a measure of the size of the shape in the direction of its minor axis.
     """
 function get_minor_axis_length(ev::Vector{Float64})::Float64
-    return ev[1] >= 0 ? Float64(4*sqrt(ev[1])) : NaN
+    return ev[1] >= 0 ? 4.0 * sqrt(ev[1]) : NaN
 end
 
 """
@@ -164,7 +192,7 @@ end
     This is a measure of how elongated the shape is.
     """
 function get_elongation(ev::Vector{Float64})::Float64
-    return Float64(sqrt(ev[1]/ev[2]))
+    return sqrt(ev[1] / ev[2])
 end
 
 """
@@ -174,44 +202,26 @@ Original C code: https://github.com/AIM-Harvard/pyradiomics/blob/master/radiomic
 function calculate_mesh_diameter2d(points_flat::Vector{Float64})::Float64
     n = div(length(points_flat), 2)
     n < 2 && return 0.0
-    
-    # 1. Costruiamo l'array di tuple
-    pts = Vector{Tuple{Float64, Float64}}(undef, n)
+
+    # 1. Build the array of tuples
+    pts = Vector{Tuple{Float64,Float64}}(undef, n)
     @inbounds for i in 1:n
         pts[i] = (points_flat[2i-1], points_flat[2i])
     end
-    
     sort!(pts)
-    
-    # 2. Pre-allochiamo l'array per l'involucro (dimensione massima possibile: 2n)
-    hull = Vector{Tuple{Float64, Float64}}(undef, 2n)
-    k = 0 # Contatore che fa da puntatore per la cima dello "stack"
-    
-    # Involucro inferiore
+
+    # 2. Pre-allocate the hull array (maximum possible size: 2n)
+    hull = Vector{Tuple{Float64,Float64}}(undef, 2n)
+    k = 0
+
+    # Lower hull
     @inbounds for i in 1:n
         p = pts[i]
-        while k >= 2 
+        while k >= 2
             o = hull[k-1]
             a = hull[k]
-            # Prodotto vettoriale inline per evitare overhead di chiamate a funzione
-            if (a[2] - o[2]) * (p[1] - o[1]) - (a[1] - o[1]) * (p[2] - o[2]) <= 0
-                k -= 1 # Equivale a un pop!
-            else
-                break
-            end
-        end
-        k += 1
-        hull[k] = p # Equivale a un push!
-    end
-    
-    # Involucro superiore
-    t = k + 1
-    @inbounds for i in n-1:-1:1
-        p = pts[i]
-        while k >= t
-            o = hull[k-1]
-            a = hull[k]
-            if (a[2] - o[2]) * (p[1] - o[1]) - (a[1] - o[1]) * (p[2] - o[2]) <= 0
+            # Inline cross product to avoid function call overhead
+            if (a[2]-o[2])*(p[1]-o[1]) - (a[1]-o[1])*(p[2]-o[2]) <= 0
                 k -= 1
             else
                 break
@@ -220,22 +230,36 @@ function calculate_mesh_diameter2d(points_flat::Vector{Float64})::Float64
         k += 1
         hull[k] = p
     end
-    
-    # 3. Calcolo della massima distanza sui vertici (h = k - 1 per ignorare il punto duplicato)
+
+    # Upper hull
+    t = k + 1
+    @inbounds for i in n-1:-1:1
+        p = pts[i]
+        while k >= t
+            o = hull[k-1]
+            a = hull[k]
+            if (a[2]-o[2])*(p[1]-o[1]) - (a[1]-o[1])*(p[2]-o[2]) <= 0
+                k -= 1
+            else
+                break
+            end
+        end
+        k += 1
+        hull[k] = p
+    end
+
+    # 3. Compute maximum distance over hull vertices (h = k-1 to ignore duplicate point)
     h = k - 1
     max_dist2 = 0.0
-    
     @inbounds for i in 1:h
         p1 = hull[i]
         for j in (i+1):h
             p2 = hull[j]
-            dist2 = (p1[1] - p2[1])^2 + (p1[2] - p2[2])^2
-            if dist2 > max_dist2
-                max_dist2 = dist2
-            end
+            dist2 = (p1[1]-p2[1])^2 + (p1[2]-p2[2])^2
+            dist2 > max_dist2 && (max_dist2 = dist2)
         end
     end
-    
+
     return sqrt(max_dist2)
 end
 
@@ -246,7 +270,7 @@ end
     # Returns
     - A tuple containing perimeter, surface, and maximum diameter as Float64 values.
     """
-function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float64})::Tuple{Float64, Float64, Float64}
+function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float64})::Tuple{Float64,Float64,Float64}
     """
     The marching squares algorithm iterates from iy = 1 to ny - 1, so row 0 and row ny - 1
     are never used as the top-left corner of a cell.
@@ -279,43 +303,16 @@ function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float
     mask = padded
 
     perimeter = 0.0
-    surface = 0.0
+    surface   = 0.0
 
-    # lookup tables
-    grid_angles_2d = ((0,0), (0,1), (1,1), (1,0))
-    
-    line_table_2d = [
-        (-1, -1, -1, -1, -1),
-        ( 3,  0, -1, -1, -1),
-        ( 0,  1, -1, -1, -1),
-        ( 3,  1, -1, -1, -1),
-        ( 1,  2, -1, -1, -1),
-        ( 1,  2,  3,  0, -1),
-        ( 0,  2, -1, -1, -1),
-        ( 3,  2, -1, -1, -1),
-        ( 2,  3, -1, -1, -1),
-        ( 2,  0, -1, -1, -1),
-        ( 0,  1,  2,  3, -1),
-        ( 2,  1, -1, -1, -1),
-        ( 1,  3, -1, -1, -1),
-        ( 1,  0, -1, -1, -1),
-        ( 0,  3, -1, -1, -1),
-        (-1, -1, -1, -1, -1),
-    ]
-
-    vert_list_2d = [
-        (0.0, 0.5), (0.5, 1.0), (1.0, 0.5), (0.5, 0.0)
-    ]
-    points_edges = ((0, 2), (3, 2))
-
-    ny, nx = size(mask)  # Automatically get the size of the mask
+    ny, nx = size(mask)
     vertices = Float64[]
-    
-    for iy in 1:(ny - 1)
-        for ix in 1:(nx - 1)
+
+    @inbounds for iy in 1:(ny-1)
+        for ix in 1:(nx-1)
             square_idx = 0
             for a_idx in 1:4
-                dy, dx = grid_angles_2d[a_idx]
+                dy, dx = GRID_ANGLES_2D[a_idx]
                 y = iy + dy
                 x = ix + dx
                 if 1 <= y <= ny && 1 <= x <= nx
@@ -325,27 +322,24 @@ function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float
                 end
             end
 
-            if square_idx == 0 || square_idx == 0xF
-                continue
-            end
+            (square_idx == 0 || square_idx == 0xF) && continue
 
             t = 1
-            while line_table_2d[square_idx + 1][t * 2 - 1] >= 0
-                a = [iy - 1.0, ix - 1.0]
-                b = copy(a)
-                for d in 1:2
-                    a[d] += vert_list_2d[line_table_2d[square_idx + 1][t * 2 - 1] + 1][d]
-                    b[d] += vert_list_2d[line_table_2d[square_idx + 1][t * 2] + 1][d]
-                    a[d] *= spacing[d]
-                    b[d] *= spacing[d]
-                end
+            while LINE_TABLE_2D[square_idx + 1][t * 2 - 1] >= 0
+                va = LINE_TABLE_2D[square_idx + 1][t * 2 - 1] + 1
+                vb = LINE_TABLE_2D[square_idx + 1][t * 2] + 1
+
+                a1 = (iy - 1.0 + VERT_LIST_2D[va][1]) * spacing[1]
+                a2 = (ix - 1.0 + VERT_LIST_2D[va][2]) * spacing[2]
+                b1 = (iy - 1.0 + VERT_LIST_2D[vb][1]) * spacing[1]
+                b2 = (ix - 1.0 + VERT_LIST_2D[vb][2]) * spacing[2]
 
                 # Surface (cross product z)
-                surface += (a[1]*b[2]) - (b[1]*a[2])
+                surface += (a1 * b2) - (b1 * a2)
 
                 # Perimeter (Euclidean distance)
-                dist = sqrt((a[1] - b[1])^2 + (a[2] - b[2])^2)
-                perimeter += dist
+                perimeter += sqrt((a1 - b1)^2 + (a2 - b2)^2)
+
                 t += 1
             end
 
@@ -354,15 +348,15 @@ function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float
                 square_idx ⊻= 0xF
             end
             for t in 1:2
-                if square_idx & (1 << points_edges[1][t]) != 0
-                    push!(vertices, ((iy - 1) + vert_list_2d[points_edges[2][t] + 1][1]) * spacing[1])
-                    push!(vertices, ((ix - 1) + vert_list_2d[points_edges[2][t] + 1][2]) * spacing[2])
+                if square_idx & (1 << POINTS_EDGES_2D[1][t]) != 0
+                    push!(vertices, (iy - 1 + VERT_LIST_2D[POINTS_EDGES_2D[2][t] + 1][1]) * spacing[1])
+                    push!(vertices, (ix - 1 + VERT_LIST_2D[POINTS_EDGES_2D[2][t] + 1][2]) * spacing[2])
                 end
             end
         end
     end
 
-    surface = abs(surface) / 2.0
+    surface  = abs(surface) / 2.0
     diameter = calculate_mesh_diameter2d(vertices)
     return Float64(perimeter), Float64(surface), Float64(diameter)
 end

--- a/src/shape_2D_features.jl
+++ b/src/shape_2D_features.jl
@@ -9,11 +9,10 @@ using LinearAlgebra
     # Returns
     - A dictionary where keys are the feature names and values are the calculated feature values.
     """
-function get_shape2d_features(mask_array::BitArray{2}, 
-                               spacing::Vector{Float64}; 
+function get_shape2d_features(mask_array::BitArray{2},
+                               spacing::Vector{Float64};
                                verbose::Bool=false,
-                               keep_largest_only = true
-                               )
+                               keep_largest_only::Bool=true)::Dict{String,Any}
 
     verbose && println("Extracting 2D shape features...")
 

--- a/src/shape_2D_features.jl
+++ b/src/shape_2D_features.jl
@@ -4,13 +4,13 @@ using LinearAlgebra
     Extract 2D shape features from a binary mask.   
     # Arguments
     - `mask_array`: 2D BitArray representing the binary mask of the shape.
-    - `spacing`: Vector of Float32 representing the pixel spacing in each dimension.
+    - `spacing`: Vector of Float64 representing the pixel spacing in each dimension.
     - `verbose`: Bool indicating whether to print progress messages.    
     # Returns
     - A dictionary where keys are the feature names and values are the calculated feature values.
     """
 function get_shape2d_features(mask_array::BitArray{2}, 
-                               spacing::Vector{Float32}; 
+                               spacing::Vector{Float64}; 
                                verbose::Bool=false,
                                keep_largest_only = true
                                )
@@ -71,40 +71,40 @@ end
 """Calculate the perimeter to surface ratio.
     Perimeter Surface Ratio = Perimeter / Surface
     # Arguments
-    - perimeter: Float32 representing the perimeter of the shape.
-    - surface: Float32 representing the surface area of the shape.
+    - perimeter: Float64 representing the perimeter of the shape.
+    - surface: Float64 representing the surface area of the shape.
     # Returns
-    - Float32 representing the perimeter to surface ratio.
+    - Float64 representing the perimeter to surface ratio.
     """
-function get_perimeter_surface_ratio(perimeter::Float32, surface::Float32)::Float32
-    return Float32(perimeter / surface)
+function get_perimeter_surface_ratio(perimeter::Float64, surface::Float64)::Float64
+    return Float64(perimeter / surface)
 end
 
 """Calculate the sphericity of a 2D shape.
     Sphericity = (2 * sqrt(π * Surface)) / Perimeter
     # Arguments
-    - perimeter: Float32 representing the perimeter of the shape.
-    - surface: Float32 representing the surface area of the shape.
+    - perimeter: Float64 representing the perimeter of the shape.
+    - surface: Float64 representing the surface area of the shape.
     # Returns
-    - Float32 representing the sphericity of the shape.
+    - Float64 representing the sphericity of the shape.
     """
-function get_sphericity(perimeter::Float32, surface::Float32)::Float32
-    return Float32((2 * sqrt(pi * surface)) / perimeter)
+function get_sphericity(perimeter::Float64, surface::Float64)::Float64
+    return Float64((2 * sqrt(pi * surface)) / perimeter)
 end
 
 """Calculate the eigenvalues of the covariance matrix of the shape's voxel coordinates.
     # Arguments
     - `mask`: 2D Boolean matrix representing the binary mask of the shape.
-    - `spacing`: Vector of Float32 representing the pixel spacing in each dimension.
+    - `spacing`: Vector of Float64 representing the pixel spacing in each dimension.
     # Returns
-    - Vector of Float32 containing the eigenvalues sorted in ascending order.
+    - Vector of Float64 containing the eigenvalues sorted in ascending order.
     """
-function get_eigenvalues(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float32})::Vector{Float32}
+function get_eigenvalues(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float64})::Vector{Float64}
     coords = Iterators.filter(i -> mask[i], CartesianIndices(mask))
     Np = count(_ -> true, coords)
 
     if Np == 0
-        return zeros(Float32, 2)
+        return zeros(Float64, 2)
     end
 
     offset_x = (0:size(mask, 1)-1) .* spacing[1]
@@ -113,7 +113,7 @@ function get_eigenvalues(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float32})
     points = [(offset_x[c[1]], offset_y[c[2]]) for c in coords]
 
     if isempty(points)
-        return zeros(Float32, 2)
+        return zeros(Float64, 2)
     end
 
     xs = Float64[x for (x, _) in points]
@@ -128,18 +128,18 @@ function get_eigenvalues(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float32})
 
     eigvals = eigen(covmat).values
 
-    return Float32.(sort(eigvals, rev=false))
+    return Float64.(sort(eigvals, rev=false))
 end
 
 """Calculate the pixel surface area of the shape represented by the binary mask.
     # Arguments
     - mask: 2D Boolean matrix representing the binary mask of the shape.
-    - spacing: Vector of Float32 representing the pixel spacing in each dimension.
+    - spacing: Vector of Float64 representing the pixel spacing in each dimension.
     # Returns
-    - Float32 representing the pixel surface area of the shape.
+    - Float64 representing the pixel surface area of the shape.
     """
-function get_pixel_surface(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float32})::Float32
-    return Float32(count(mask) * (spacing[1] * spacing[2]))
+function get_pixel_surface(mask::AbstractMatrix{<:Bool}, spacing::Vector{Float64})::Float64
+    return Float64(count(mask) * (spacing[1] * spacing[2]))
 end
 
 """
@@ -147,8 +147,8 @@ end
     where eigenvalue[2] is the second largest eigenvalue of the covariance matrix.
     This is a measure of the size of the shape in the direction of its major axis.
     """
-function get_major_axis_length(ev::Vector{Float32})::Float32
-    return ev[2] >= 0 ? Float32(4*sqrt(ev[2])) : NaN
+function get_major_axis_length(ev::Vector{Float64})::Float64
+    return ev[2] >= 0 ? Float64(4*sqrt(ev[2])) : NaN
 end
 
 """
@@ -156,16 +156,16 @@ end
     where eigenvalue[1] is the smallest eigenvalue of the covariance matrix.
     This is a measure of the size of the shape in the direction of its minor axis.
     """
-function get_minor_axis_length(ev::Vector{Float32})::Float32
-    return ev[1] >= 0 ? Float32(4*sqrt(ev[1])) : NaN
+function get_minor_axis_length(ev::Vector{Float64})::Float64
+    return ev[1] >= 0 ? Float64(4*sqrt(ev[1])) : NaN
 end
 
 """
     Elongation is calculated as the ratio of the major axis length to the minor axis length.
     This is a measure of how elongated the shape is.
     """
-function get_elongation(ev::Vector{Float32})::Float32
-    return Float32(sqrt(ev[1]/ev[2]))
+function get_elongation(ev::Vector{Float64})::Float64
+    return Float64(sqrt(ev[1]/ev[2]))
 end
 
 """
@@ -243,11 +243,11 @@ end
 """Calculate perimeter, surface, and maximum diameter of a 2D shape represented by a binary mask.
     # Arguments
     - mask: 2D Integer matrix representing the binary mask of the shape.
-    - spacing: Vector of Float32 representing the pixel spacing in each dimension.
+    - spacing: Vector of Float64 representing the pixel spacing in each dimension.
     # Returns
-    - A tuple containing perimeter, surface, and maximum diameter as Float32 values.
+    - A tuple containing perimeter, surface, and maximum diameter as Float64 values.
     """
-function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float32})::Tuple{Float32, Float32, Float32}
+function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float64})::Tuple{Float64, Float64, Float64}
     """
     The marching squares algorithm iterates from iy = 1 to ny - 1, so row 0 and row ny - 1
     are never used as the top-left corner of a cell.
@@ -365,5 +365,5 @@ function get_coefficients(mask::AbstractMatrix{<:Integer}, spacing::Vector{Float
 
     surface = abs(surface) / 2.0
     diameter = calculate_mesh_diameter2d(vertices)
-    return Float32(perimeter), Float32(surface), Float32(diameter)
+    return Float64(perimeter), Float64(surface), Float64(diameter)
 end

--- a/src/shape_3D_features.jl
+++ b/src/shape_3D_features.jl
@@ -55,7 +55,7 @@ function marching_cubes_surface(mask::BitArray{3},
     triangles  = Vector{Triangle3D}()
     sizehint!(triangles, count(mask) * 2)
 
-    for z in 1:nz-1, y in 1:ny-1, x in 1:nx-1
+    @inbounds for z in 1:nz-1, y in 1:ny-1, x in 1:nx-1
 
         v0 = Float64(mask[x,   y,   z  ])
         v1 = Float64(mask[x+1, y,   z  ])
@@ -149,13 +149,16 @@ function maximum_3d_diameter(triangles::Vector{Triangle3D};
                               min_samples::Int     = 100)
     isempty(triangles) && return 0.0
 
-    uniq = Set{Point3D}()
-    sizehint!(uniq, length(triangles) * 3)
+    verts = Vector{Point3D}(undef, length(triangles) * 3)
+    k = 1
     @inbounds for (a, b, c) in triangles
-        push!(uniq, a); push!(uniq, b); push!(uniq, c)
+        verts[k]   = a
+        verts[k+1] = b
+        verts[k+2] = c
+        k += 3
     end
-    verts = collect(uniq)
-    n     = length(verts)
+    unique!(verts)
+    n = length(verts)
     n < 2 && return 0.0
 
     if sample_rate < 1.0

--- a/src/shape_3D_features.jl
+++ b/src/shape_3D_features.jl
@@ -157,20 +157,76 @@ function maximum_3d_diameter(triangles::Vector{Triangle3D})::Float64
         k += 3
     end
     unique!(verts)
-    n = length(verts)
-    n < 2 && return 0.0
-
-    max_sq = 0.0
     nv = length(verts)
-    @inbounds for i in 1:nv-1
-        pi = verts[i]
-        for j in i+1:nv
-            pj = verts[j]
-            d  = (pi[1]-pj[1])^2 + (pi[2]-pj[2])^2 + (pi[3]-pj[3])^2
-            d > max_sq && (max_sq = d)
+    nv < 2 && return 0.0
+
+    # Find the center of the bounding box
+    min_x = min_y = min_z = Inf
+    max_x = max_y = max_z = -Inf
+    @inbounds for p in verts
+        p[1] < min_x && (min_x = p[1])
+        p[1] > max_x && (max_x = p[1])
+        p[2] < min_y && (min_y = p[2])
+        p[2] > max_y && (max_y = p[2])
+        p[3] < min_z && (min_z = p[3])
+        p[3] > max_z && (max_z = p[3])
+    end
+    cx = (min_x + max_x) / 2
+    cy = (min_y + max_y) / 2
+    cz = (min_z + max_z) / 2
+
+    # Calculate the squared distance from the center for each point
+    d2_center = Vector{Float64}(undef, nv)
+    @inbounds for i in 1:nv
+        p = verts[i]
+        d2_center[i] = (p[1]-cx)^2 + (p[2]-cy)^2 + (p[3]-cz)^2
+    end
+
+    # Sort the points by distance from the center in descending order
+    perm = sortperm(d2_center, rev=true)
+    verts_sorted = verts[perm]
+    d_center_sorted = sqrt.(d2_center[perm])
+
+    # Search for the maximum diameter with Pruning (Triangle Inequality)
+    max_sq = 0.0
+    max_d = 0.0
+
+    # Heuristics to get a good lower-bound (distances from the first point, the most external)
+    p1 = verts_sorted[1]
+    @inbounds for j in 2:nv
+        p2 = verts_sorted[j]
+        d2 = (p1[1]-p2[1])^2 + (p1[2]-p2[2])^2 + (p1[3]-p2[3])^2
+        if d2 > max_sq
+            max_sq = d2
+            max_d = sqrt(max_sq)
         end
     end
-    return sqrt(max_sq)
+
+    @inbounds for i in 1:nv-1
+        # Outer pruning: if twice the distance of P_i from the center does not exceed the current diameter,
+        # no subsequent point (being closer to the center) can ever form a larger diameter.
+        if 2.0 * d_center_sorted[i] <= max_d
+            break
+        end
+
+        pi = verts_sorted[i]
+        for j in i+1:nv
+            # Inner pruning: if the sum of the distances of P_i and P_j from the center does not exceed the diameter,
+            # the same applies to all points P_k with k >= j.
+            if d_center_sorted[i] + d_center_sorted[j] <= max_d
+                break
+            end
+
+            pj = verts_sorted[j]
+            d2 = (pi[1]-pj[1])^2 + (pi[2]-pj[2])^2 + (pi[3]-pj[3])^2
+            if d2 > max_sq
+                max_sq = d2
+                max_d = sqrt(max_sq)
+            end
+        end
+    end
+    
+    return max_d
 end
 """
     This function is used to get the voxel coordinates of a mesh.

--- a/src/shape_3D_features.jl
+++ b/src/shape_3D_features.jl
@@ -233,7 +233,7 @@ function voxel_volume(mask, spacing::Vector{<:Real})
            Float64(spacing[1]) * Float64(spacing[2]) * Float64(spacing[3])
 end
 """
-    get_shape3d_features(mask::AbstractArray{<:Real, 3}, spacing::Vector{Float32}; verbose=false, keep_largest_only=true, pad_width=1, threshold=0)
+    get_shape3d_features(mask::AbstractArray{<:Real, 3}, spacing::Vector{Float64}; verbose=false, keep_largest_only=true, pad_width=1, threshold=0)
     
     Extracts 3D shape features from the given mask.
     

--- a/src/shape_3D_features.jl
+++ b/src/shape_3D_features.jl
@@ -254,12 +254,12 @@ end
         - By default, only the largest connected component is kept to ensure meaningful shape features.
 """
 function get_shape3d_features(mask::AbstractArray{<:Real,3},
-                               spacing::Vector{<:Real};
-                               verbose           = false,
-                               keep_largest_only = true,
-                               pad_width         = 1,
-                               threshold         = 0.5,
-                               sample_rate       = 0.03)
+                               spacing::Vector{Float64};
+                               verbose::Bool           = false,
+                               keep_largest_only::Bool = true,
+                               pad_width::Int          = 1,
+                               threshold::Float64      = 0.5,
+                               sample_rate::Float64    = 0.03)::Dict{String,Any}
 
     spacing_f64 = convert(Vector{Float64}, spacing)
     verbose && println("Extracting 3D shape features...")

--- a/src/shape_3D_features.jl
+++ b/src/shape_3D_features.jl
@@ -50,7 +50,7 @@ end
 """
 function marching_cubes_surface(mask::BitArray{3},
                                  spacing::Vector{Float64},
-                                 isolevel::Float64=0.5)
+                                 isolevel::Float64=0.5)::Vector{Triangle3D}
     nx, ny, nz = size(mask)
     triangles  = Vector{Triangle3D}()
     sizehint!(triangles, count(mask) * 2)
@@ -116,7 +116,7 @@ end
     This function is used to calculate the surface area and volume of a mesh.
     It is used by the marching cubes algorithm to create a surface mesh from a 3D binary mask.
 """
-function calculate_mesh_metrics(triangles::Vector{Triangle3D})
+function calculate_mesh_metrics(triangles::Vector{Triangle3D})::Tuple{Float64, Float64}
     area   = 0.0
     volume = 0.0
     @inbounds for (p1, p2, p3) in triangles
@@ -136,7 +136,7 @@ end
     This function is used to calculate the sphericity of a mesh.
     It is used by the marching cubes algorithm to create a surface mesh from a 3D binary mask.
 """
-function sphericity(area::Float64, volume::Float64)
+function sphericity(area::Float64, volume::Float64)::Float64
     (area <= 0.0 || volume <= 0.0) && return 0.0
     return (π^(1/3) * (6.0 * volume)^(2/3)) / area
 end
@@ -144,9 +144,8 @@ end
     This function is used to calculate the maximum 3D diameter of a mesh.
     It is used by the marching cubes algorithm to create a surface mesh from a 3D binary mask.
 """
-function maximum_3d_diameter(triangles::Vector{Triangle3D};
-                              sample_rate::Float64 = 0.03,
-                              min_samples::Int     = 100)
+function maximum_3d_diameter(triangles::Vector{Triangle3D})::Float64
+
     isempty(triangles) && return 0.0
 
     verts = Vector{Point3D}(undef, length(triangles) * 3)
@@ -160,14 +159,6 @@ function maximum_3d_diameter(triangles::Vector{Triangle3D};
     unique!(verts)
     n = length(verts)
     n < 2 && return 0.0
-
-    if sample_rate < 1.0
-        ns = min(n, max(min_samples, Int(ceil(n * sample_rate))))
-        if ns < n
-            Random.seed!(42)
-            verts = verts[randperm(n)[1:ns]]
-        end
-    end
 
     max_sq = 0.0
     nv = length(verts)
@@ -185,7 +176,7 @@ end
     This function is used to get the voxel coordinates of a mesh.
     It is used by the marching cubes algorithm to create a surface mesh from a 3D binary mask.
 """
-function get_voxel_coords(mask::AbstractArray{Bool,3}, spacing::Vector{<:Real})
+function get_voxel_coords(mask::AbstractArray{Bool,3}, spacing::Vector{Float64})::Vector{Point3D}
     n      = count(mask)
     coords = Vector{Point3D}(undef, n)
     k      = 1
@@ -203,7 +194,7 @@ end
     This function is used to calculate the principal axes features of a mesh.
     It is used by the marching cubes algorithm to create a surface mesh from a 3D binary mask.
 """
-function principal_axes_features(coords::Vector{Point3D})
+function principal_axes_features(coords::Vector{Point3D})::Tuple{Vector{Float64}, Float64, Float64}
     n = length(coords)
     n < 2 && return zeros(Float64, 3), NaN, NaN
 
@@ -231,7 +222,7 @@ end
     This function is used to calculate the voxel volume of a mesh.
     It is used by the marching cubes algorithm to create a surface mesh from a 3D binary mask.
 """
-function voxel_volume(mask, spacing::Vector{<:Real})
+function voxel_volume(mask::AbstractArray, spacing::Vector{Float64})::Float64
     return Float64(count(mask)) *
            Float64(spacing[1]) * Float64(spacing[2]) * Float64(spacing[3])
 end
@@ -261,10 +252,8 @@ function get_shape3d_features(mask::AbstractArray{<:Real,3},
                                verbose::Bool           = false,
                                keep_largest_only::Bool = true,
                                pad_width::Int          = 1,
-                               threshold::Float64      = 0.5,
-                               sample_rate::Float64    = 0.03)::Dict{String,Any}
+                               threshold::Float64      = 0.5)::Dict{String,Any}
 
-    spacing_f64 = convert(Vector{Float64}, spacing)
     verbose && println("Extracting 3D shape features...")
 
     if keep_largest_only
@@ -283,12 +272,12 @@ function get_shape3d_features(mask::AbstractArray{<:Real,3},
 
     task_axes = Threads.@spawn begin
         verbose && println("[Thread 1] Calculating principal axes...")
-        coords = get_voxel_coords(processed_mask, spacing_f64)
+        coords = get_voxel_coords(processed_mask, spacing)
         principal_axes_features(coords)
     end
 
     verbose && println("[Main Thread] Running Marching Cubes...")
-    triangles = marching_cubes_surface(processed_mask, spacing_f64)
+    triangles = marching_cubes_surface(processed_mask, spacing)
 
     task_geom = Threads.@spawn begin
         verbose && println("[Thread 2] Calculating surface features...")
@@ -300,10 +289,10 @@ function get_shape3d_features(mask::AbstractArray{<:Real,3},
 
     task_diam = Threads.@spawn begin
         verbose && println("[Thread 3] Calculating maximum diameter...")
-        maximum_3d_diameter(triangles; sample_rate=Float64(sample_rate))
+        maximum_3d_diameter(triangles)
     end
 
-    vol_voxel                          = voxel_volume(processed_mask, spacing_f64)
+    vol_voxel                          = voxel_volume(processed_mask, spacing)
     axes_lengths, elongation, flatness = fetch(task_axes)
     area, meshvol, vol_ratio, sph      = fetch(task_geom)
     maxdiam                            = fetch(task_diam)

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -233,43 +233,6 @@ function discretize_image(img::AbstractArray{Float64},
 end
 
 """
-    get_neighbors!(neighbors::AbstractVector{Int},
-                     idx::Int,
-                     dims::NTuple{N,Int} where N)::Int
-
-    Gets the 26-connected neighbors of a voxel in a 3D image securely into a pre-allocated array.
-
-    # Arguments
-    - `neighbors`: The pre-allocated vector to store the linear indices of the neighbors.
-    - `idx`: The linear index of the voxel.
-    - `dims`: The dimensions of the image.
-
-    # Returns
-    - The number of valid neighbors found.
-    """
-@inline function get_neighbors!(neighbors::AbstractVector{Int},
-                                 idx::Int,
-                                 dims::NTuple{N,Int} where N)::Int
-    n = ndims(CartesianIndices(dims))
-    count = 0
-
-    cartesian_idx = CartesianIndices(dims)[idx]
-    linear_indices = LinearIndices(dims)
-    cartesian_range = CartesianIndices(dims)
-
-    @inbounds for offset in CartesianIndices(ntuple(_ -> -1:1, n))
-        all(t -> t == 0, Tuple(offset)) && continue
-        new_cartesian_idx = cartesian_idx + offset
-        if checkbounds(Bool, cartesian_range, new_cartesian_idx)
-            count += 1
-            neighbors[count] = linear_indices[new_cartesian_idx]
-        end
-    end
-
-    return count
-end
-
-"""
     get_neighbors(idx::Int,
                    dims::NTuple{N,Int} where N)::Vector{Int}
 

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -13,10 +13,19 @@
     # Returns
     - `cropped_img`: image array cropped to the bounding box of the mask.
     - `cropped_mask`: binary mask array (`BitArray`) cropped to the same bounding box."""
-function bounding_box(img, mask, verbose::Bool)
+function bounding_box(img, mask, verbose::Bool; log_buffer::Union{Vector{String}, Nothing}=nothing)
+    function _bb_log(msg)
+        if !isnothing(log_buffer)
+            push!(log_buffer, msg)
+        else
+            println(msg)
+        end
+    end
+
     if verbose
-        println("Calculating the bounding box")
-        println("Image data: $(size(img)) | $(prod(size(img))) voxels\nMask data: $(size(mask)) | $(count(mask .== 1)) voxels")
+        _bb_log("Calculating the bounding box")
+        _bb_log("Image data: $(size(img)) | $(prod(size(img))) voxels")
+        _bb_log("Mask data: $(size(mask)) | $(count(mask .== 1)) voxels")
     end
 
     idx = findall(mask .== 1)
@@ -41,7 +50,7 @@ function bounding_box(img, mask, verbose::Bool)
         img_size = size(cropped_img)
         ct_voxels = prod(img_size)
         image_crop_perc = 100 - prod(img_size) / prod(size(img)) * 100
-        println("Cropped image data: $img_size | $ct_voxels voxels | $(round(image_crop_perc, digits=2))% reduction ")
+        _bb_log("Cropped image data: $img_size | $ct_voxels voxels | $(round(image_crop_perc, digits=2))% reduction ")
     end
 
     return cropped_img, BitArray(cropped_mask)

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -72,9 +72,9 @@ function label_components(mask::AbstractArray{Bool})
 end
 
 """
-    discretize_image(img::Array{Float32,3}, mask::BitArray{3}; 
+    discretize_image(img::Array{<:Real}, mask::BitArray; 
                         n_bins::Union{Int,Nothing}=nothing,
-                        bin_width::Union{Float64,Nothing}=nothing)
+                        bin_width::Union{<:Real,Nothing}=nothing)
 
     Discretizes the input image for radiomics feature calculation. 
     Takes into account only the voxels within the provided mask.
@@ -82,12 +82,12 @@ end
     You can specify EITHER n_bins (number of bins) OR bin_width (width of each bin), but not both.
     - If n_bins is specified, bin_width is calculated automatically from the intensity range
     - If bin_width is specified, the number of bins is calculated automatically
-    - If neither is specified, defaults to bin_width=25.0f0
+    - If neither is specified, defaults to bin_width=25.0
 
     This function is compatible with all radiomics features: GLCM, GLDM, GLRLM, GLSZM, NGTDM, etc.
 
     # Arguments:
-        - `img`: The input 3D image as Float32 array.
+        - `img`: The input 3D image as Float64 array.
         - `mask`: The mask defining the region of interest as BitArray.
         - `n_bins`: The number of discrete gray levels (optional).
         - `bin_width`: The width of each bin (optional).
@@ -103,9 +103,9 @@ end
         disc, n_bins, levels, bw = discretize_image(img, mask, n_bins=64)
         
         # Using fixed bin width (number of bins calculated automatically)
-        disc, n_bins, levels, bw = discretize_image(img, mask, bin_width=25.0f0)
+        disc, n_bins, levels, bw = discretize_image(img, mask, bin_width=25.0)
         
-        # Default (bin_width=25.0f0)
+        # Default (bin_width=25.0)
         disc, n_bins, levels, bw = discretize_image(img, mask)
     """
 function discretize_image(img::Array{<:Real},
@@ -113,52 +113,51 @@ function discretize_image(img::Array{<:Real},
     n_bins::Union{Int,Nothing}=nothing,
     bin_width::Union{<:Real,Nothing}=nothing)
 
-    # Convert to Float32 for backward compatibility
-    img_f32 = convert(Array{Float32}, img)
-    bin_width_f32 = isnothing(bin_width) ? nothing : Float32(bin_width)
+    # Convert to Float64 for backward compatibility
+    img_f64 = convert(Array{Float64}, img)
+    bin_width_f64 = isnothing(bin_width) ? nothing : Float64(bin_width)
 
     # Early check for empty mask
     if sum(mask) == 0
-        return zeros(Int, size(img_f32)), 0, Int[], 0.0f0
+        return zeros(Int, size(img_f64)), 0, Int[], 0.0
     end
 
     # Compute min/max from masked values
-    vals = view(img_f32, mask)
+    vals = view(img_f64, mask)
     vmin = minimum(vals)
     vmax = maximum(vals)
 
-    if !isnothing(n_bins) && !isnothing(bin_width_f32)
-        error("Specify either n_bins or bin_width, not both.")
+    disc = zeros(Int, size(img_f64))
 
-    elseif isnothing(n_bins) && isnothing(bin_width_f32)
-        bin_width_f32 = 25.0f0
+    if !isnothing(n_bins) && !isnothing(bin_width_f64)
+        error("Specify either n_bins or bin_width, not both.")
+    elseif isnothing(n_bins) && isnothing(bin_width_f64)
+        bin_width_f64 = 25.0
     end
 
-    disc = zeros(Int, size(img_f32))
-
     if !isnothing(n_bins)
-        bin_width_used = (vmax - vmin) / Float32(n_bins)
-        if bin_width_used ≈ 0.0f0
-            bin_width_used = 1.0f0
+        bin_width_used = (vmax - vmin) / Float64(n_bins)
+        if bin_width_used ≈ 0.0
+            bin_width_used = 1.0
         end
 
-        inv_bin_width = 1.0f0 / bin_width_used
+        inv_bin_width = 1.0 / bin_width_used
         # Iterate directly using linear indices without allocating index array
         @inbounds for i in eachindex(mask)
             if mask[i]
-                v = img_f32[i]
+                v = img_f64[i]
                 b = min(Int(floor((v - vmin) * inv_bin_width)) + 1, n_bins)
                 disc[i] = b
             end
         end
     else
-        bin_width_used = bin_width_f32
-        inv_bin_width = 1.0f0 / bin_width_used
+        bin_width_used = bin_width_f64
+        inv_bin_width = 1.0 / bin_width_used
         bin_offset = Int(floor(vmin * inv_bin_width))
 
         @inbounds for i in eachindex(mask)
             if mask[i]
-                v = img_f32[i]
+                v = img_f64[i]
                 b = Int(floor(v * inv_bin_width)) - bin_offset + 1
                 disc[i] = b
             end
@@ -360,18 +359,18 @@ function prepare_inputs(img_input::AbstractArray,
     voxel_spacing_input::AbstractVector)
     # Handle both 2D and 3D inputs
     if ndims(img_input) == 2
-        # 2D input: convert to 2D Float32 array
-        img = convert(Array{Float32,2}, img_input)
-        mask = BitArray(mask_input .!= 0.0f0)
+        # 2D input: convert to 2D Float64 array
+        img = convert(Array{Float64,2}, img_input)   
+        mask = BitArray(mask_input .!= 0.0)           
     elseif ndims(img_input) == 3
-        # 3D input: convert to 3D Float32 array
-        img = convert(Array{Float32,3}, img_input)
-        mask = BitArray(mask_input .!= 0.0f0)
+        # 3D input: convert to 3D Float64 array
+        img = convert(Array{Float64,3}, img_input)   
+        mask = BitArray(mask_input .!= 0.0)
     else
         throw(ArgumentError("Input image must be 2D or 3D, got $(ndims(img_input))D"))
     end
 
-    voxel_spacing = convert(Vector{Float32}, voxel_spacing_input)
+    voxel_spacing = convert(Vector{Float64}, voxel_spacing_input)
     return img, mask, voxel_spacing
 end
 
@@ -386,7 +385,7 @@ end
 function  validate_binning_parameters(img_input, mask_input, bin_width)
 
     # Calculate range and estimated number of bins
-    roi_vals = img_input[mask_input.!=0]
+    roi_vals = img_input[mask_input]
     val_min = minimum(roi_vals)
     val_max = maximum(roi_vals)
     val_range = val_max - val_min

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,5 +1,8 @@
 """
-    bounding_box(img, mask, verbose::Bool)
+    bounding_box(img::AbstractArray{Float64},
+                 mask::AbstractArray,
+                 verbose::Bool;
+                 log_buffer::Union{Vector{String},Nothing}=nothing)::Tuple{AbstractArray{Float64}, BitArray}
 
     Computes the bounding box of a binary mask and crops both the image and the mask
     to the smallest region containing all voxels where `mask == 1`.
@@ -13,7 +16,10 @@
     # Returns
     - `cropped_img`: image array cropped to the bounding box of the mask.
     - `cropped_mask`: binary mask array (`BitArray`) cropped to the same bounding box."""
-function bounding_box(img, mask, verbose::Bool; log_buffer::Union{Vector{String}, Nothing}=nothing)
+function bounding_box(img::AbstractArray{Float64},
+                       mask::AbstractArray,
+                       verbose::Bool;
+                       log_buffer::Union{Vector{String},Nothing}=nothing)::Tuple{AbstractArray{Float64}, BitArray}
     function _bb_log(msg)
         if !isnothing(log_buffer)
             push!(log_buffer, msg)
@@ -57,7 +63,7 @@ function bounding_box(img, mask, verbose::Bool; log_buffer::Union{Vector{String}
 end
 
 """
-    label_components(mask::AbstractArray{Bool})
+    label_components(mask::AbstractArray{Bool})::Array{Int}
 
     Labels connected components in a binary mask using 26-connectivity for 3D
     (or 8-connectivity for 2D).
@@ -68,7 +74,7 @@ end
     # Returns:
         - An array of the same size as `mask` with integer labels.
     """
-function label_components(mask::AbstractArray{Bool})
+function label_components(mask::AbstractArray{Bool})::Array{Int}
     labels = zeros(Int, size(mask))
     current_label = 0
     queue = Int[]
@@ -130,9 +136,10 @@ function label_components(mask::AbstractArray{Bool})
 end
 
 """
-    discretize_image(img::Array{<:Real}, mask::BitArray; 
-                        n_bins::Union{Int,Nothing}=nothing,
-                        bin_width::Union{<:Real,Nothing}=nothing)
+    discretize_image(img::AbstractArray{Float64},
+                     mask::BitArray;
+                     n_bins::Union{Int,Nothing}=nothing,
+                     bin_width::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
 
     Discretizes the input image for radiomics feature calculation. 
     Takes into account only the voxels within the provided mask.
@@ -166,10 +173,10 @@ end
         # Default (bin_width=25.0)
         disc, n_bins, levels, bw = discretize_image(img, mask)
     """
-function discretize_image(img::Array{<:Real},
-    mask::BitArray;
-    n_bins::Union{Int,Nothing}=nothing,
-    bin_width::Union{<:Real,Nothing}=nothing)
+function discretize_image(img::AbstractArray{Float64},
+                            mask::BitArray;
+                            n_bins::Union{Int,Nothing}=nothing,
+                            bin_width::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
 
     # Convert to Float64 for backward compatibility
     img_f64 = convert(Array{Float64}, img)
@@ -229,7 +236,9 @@ function discretize_image(img::Array{<:Real},
 end
 
 """
-    get_neighbors!(neighbors::AbstractVector{Int}, idx, dims)
+    get_neighbors!(neighbors::AbstractVector{Int},
+                     idx::Int,
+                     dims::NTuple{N,Int} where N)::Int
 
     Gets the 26-connected neighbors of a voxel in a 3D image securely into a pre-allocated array.
 
@@ -241,7 +250,9 @@ end
     # Returns
     - The number of valid neighbors found.
     """
-@inline function get_neighbors!(neighbors::AbstractVector{Int}, idx, dims)
+@inline function get_neighbors!(neighbors::AbstractVector{Int},
+                                 idx::Int,
+                                 dims::NTuple{N,Int} where N)::Int
     n = ndims(CartesianIndices(dims))
     count = 0
 
@@ -262,7 +273,8 @@ end
 end
 
 """
-    get_neighbors(idx, dims)
+    get_neighbors(idx::Int,
+                   dims::NTuple{N,Int} where N)::Vector{Int}
 
     Gets the 26-connected neighbors of a voxel in a 3D image.
 
@@ -273,7 +285,8 @@ end
     # Returns
     - A vector of linear indices of the neighbors.
     """
-@inline function get_neighbors(idx, dims)
+@inline function get_neighbors(idx::Int,
+                                dims::NTuple{N,Int} where N)::Vector{Int}
     n = ndims(CartesianIndices(dims))
     max_neighbors = 3^n - 1  # 8 per 2D, 26 per 3D
     neighbors = Vector{Int}(undef, max_neighbors)
@@ -282,7 +295,7 @@ end
 end
 
 """
-    keep_largest_component(mask::AbstractArray{Bool})
+    keep_largest_component(mask::AbstractArray{Bool})::Tuple{AbstractArray{Bool}, Int}
 
     Keeps only the largest connected component in the binary mask. All other components are removed. 
     If multiple islands are detected, a warning is issued.
@@ -293,7 +306,7 @@ end
     # Returns:
         - The mask containing only the largest connected component (Array).
     """
-function keep_largest_component(mask::AbstractArray{Bool})
+function keep_largest_component(mask::AbstractArray{Bool})::Tuple{AbstractArray{Bool}, Int}
     if sum(mask) == 0
         return mask, 0  # Restituisce anche 0 isole
     end
@@ -339,7 +352,7 @@ function keep_largest_component(mask::AbstractArray{Bool})
 end
 
 """
-    pad_mask(mask::AbstractArray, pad::Int)
+    pad_mask(mask::AbstractArray{Bool}, pad::Int)::BitArray
     
     Pads the input mask with a specified number of layers of false values.
     
@@ -350,7 +363,7 @@ end
     # Returns:
         - The padded mask (Array).
     """
-@inline function pad_mask(mask::AbstractArray{Bool}, pad::Int)
+@inline function pad_mask(mask::AbstractArray{Bool}, pad::Int)::BitArray
     sz = size(mask)
     new_shape = ntuple(i -> sz[i] + 2 * pad, ndims(mask))
     new_mask = falses(new_shape)
@@ -367,7 +380,9 @@ end
         - `verbose`: If true, prints progress messages.
         # Returns:
         - Nothing. Throws an error if the inputs are invalid."""
-function input_sanity_check(img::AbstractArray, mask::AbstractArray, verbose::Bool)
+function input_sanity_check(img::AbstractArray{Float64},
+                             mask::AbstractArray,
+                             verbose::Bool)::Nothing
     if verbose
         println("Running input sanity check...")
     end
@@ -384,7 +399,9 @@ end
         - `features`: A dictionary of features to print.
         # Returns:
         - Nothing. Prints the features to the console."""
-function print_features(title::String, features::Dict{String,Any}; log_buffer::Union{Vector{String}, Nothing}=nothing)
+function print_features(title::String,
+                         features::Dict{String,Any};
+                         log_buffer::Union{Vector{String},Nothing}=nothing)::Nothing
     output = String[]
     
     push!(output, "\n--- $title ---")
@@ -402,6 +419,8 @@ function print_features(title::String, features::Dict{String,Any}; log_buffer::U
     else
         append!(log_buffer, output)
     end
+
+    return nothing
 end
 
 """
@@ -413,8 +432,8 @@ end
         # Returns:
         - A tuple containing the prepared image, mask, and voxel spacing."""
 function prepare_inputs(img_input::AbstractArray,
-    mask_input::AbstractArray,
-    voxel_spacing_input::AbstractVector)
+                         mask_input::AbstractArray,
+                         voxel_spacing_input::AbstractVector)::Tuple{AbstractArray{Float64}, AbstractArray{Int}, Vector{Float64}}
     # Handle both 2D and 3D inputs
     if ndims(img_input) == 2
         # 2D input: convert to 2D Float64 array
@@ -440,7 +459,9 @@ end
         - `bin_width`: The width of each bin (Float64).
         # Returns:
         - Nothing. Prints a warning if the binning parameters are invalid."""
-function  validate_binning_parameters(img_input, mask_input, bin_width)
+function validate_binning_parameters(img_input::AbstractArray{Float64},
+                                      mask_input::BitArray,
+                                      bin_width::Float64)::Nothing
 
     # Calculate range and estimated number of bins
     roi_vals = img_input[mask_input]
@@ -466,7 +487,8 @@ end
         - `label`: The label to extract from the mask (Int).
         # Returns:
         - A tuple containing the extracted mask and the voxel count."""
-function extract_and_check_mask(mask_input, label::Int)
+function extract_and_check_mask(mask_input::AbstractArray{Int},
+                                 label::Int)::Tuple{BitArray, Int}
     mask_to_use = (mask_input .== label)
     # Check if label exists
     voxel_count = sum(mask_to_use)

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -214,7 +214,7 @@ function discretize_image(img::AbstractArray{Float64},
             end
         end
     else
-        bin_width_used = bin_width  # già Float64
+        bin_width_used = bin_width
         inv_bin_width = 1.0 / bin_width_used
         bin_offset = Int(floor(vmin * inv_bin_width))
         @inbounds for i in eachindex(mask)
@@ -311,26 +311,6 @@ end
 end
 
 """
-    Performs sanity checks on the input image and mask.
-        # Parameters:
-        - `img`: The input image (Array).
-        - `mask`: The mask defining the region of interest (Array).
-        - `verbose`: If true, prints progress messages.
-        # Returns:
-        - Nothing. Throws an error if the inputs are invalid."""
-function input_sanity_check(img::AbstractArray{Float64},
-                             mask::AbstractArray,
-                             verbose::Bool)::Nothing
-    if verbose
-        println("Running input sanity check...")
-    end
-
-    if size(img) != size(mask)
-        throw(ArgumentError("img and mask have different size!"))
-    end
-end
-
-"""
     Helper function to print features in a formatted list.
         # Parameters:
         - `title`: The title to display before the features.
@@ -362,31 +342,139 @@ function print_features(title::String,
 end
 
 """
-    Prepares and validates the input image, mask, and voxel spacing.
-        # Parameters:
-        - `img_input`: The input image (Array).
-        - `mask_input`: The mask defining the region of interest (Array).
-        - `voxel_spacing_input`: The spacing of the voxels in the image (Array).
-        # Returns:
-        - A tuple containing the prepared image, mask, and voxel spacing."""
-function prepare_inputs(img_input::AbstractArray,
-                         mask_input::AbstractArray,
-                         voxel_spacing_input::AbstractVector)::Tuple{AbstractArray{Float64}, AbstractArray{Int}, Vector{Float64}}
-    # Handle both 2D and 3D inputs
-    if ndims(img_input) == 2
-        # 2D input: convert to 2D Float64 array
-        img = convert(Array{Float64,2}, img_input)   
-        mask = convert(Array{Int,2}, mask_input)           
+    _cast_inputs(img_input, mask_input, voxel_spacing_input,
+                 features, labels, n_bins, bin_width, weighting_norm)
+
+    Converts all input parameters to their correct concrete types.
+    Acts as a type barrier before the main feature extraction logic.
+
+    # Returns
+    - A NamedTuple with all parameters converted to their correct types.
+"""
+function _cast_inputs(
+    img_input,
+    mask_input,
+    voxel_spacing_input,
+    features,
+    labels,
+    n_bins,
+    bin_width,
+    weighting_norm,
+    slices_2d,          
+    keep_largest_only,  
+    get_raw_matrices,   
+    verbose             
+    )::NamedTuple{
+        (:img, :mask, :spacing, :features, :labels, :n_bins, :bin_width, :weighting_norm, :slices_2d, :keep_largest_only, :get_raw_matrices, :verbose),
+        Tuple{
+            Union{Array{Float64,2}, Array{Float64,3}},
+            Union{Array{Int,2}, Array{Int,3}},
+            Vector{Float64},
+            Vector{Symbol},
+            Union{Int, Vector{Int}},
+            Union{Nothing, Int},
+            Union{Nothing, Float64},
+            Union{Nothing, String}, 
+            Union{Nothing, Vector{Tuple{Int,Int}}},
+            Bool,                                     
+            Bool,                                     
+            Bool                                      
+        }
+    }
+
+    # --- Perpare input ---
+    #For img
+    # 2D input: convert to 2D Float64 array
+    img::Union{Array{Float64,2}, Array{Float64,3}} = if ndims(img_input) == 2
+        convert(Array{Float64,2}, img_input)
+    # 3D input: convert to 3D Float64 array
     elseif ndims(img_input) == 3
-        # 3D input: convert to 3D Float64 array
-        img = convert(Array{Float64,3}, img_input)   
-        mask = convert(Array{Int,3}, mask_input)
+        convert(Array{Float64,3}, img_input)
     else
         throw(ArgumentError("Input image must be 2D or 3D, got $(ndims(img_input))D"))
     end
 
-    voxel_spacing = convert(Vector{Float64}, voxel_spacing_input)
-    return img, mask, voxel_spacing
+    # For Mask
+    # 2D input: convert to 2D Float64 array
+    mask::Union{Array{Int,2}, Array{Int,3}} = if ndims(mask_input) == 2
+        convert(Array{Int,2}, mask_input)
+    # 3D input: convert to 3D Float64 array
+    elseif ndims(mask_input) == 3
+        convert(Array{Int,3}, mask_input)
+    else
+        throw(ArgumentError("Input mask must be 2D or 3D, got $(ndims(mask_input))D"))
+    end
+
+    #Conversion of mask & img and control of Sanity Check
+    if verbose
+        println("Running Conversion completed. Starting Sanity check...")
+    end
+
+    #Sanity Check
+    if size(img) != size(mask)
+         throw(ArgumentError("img and mask have different size!"))
+    end
+
+    # Convert spacing (supports any numeric vector/list)
+    spacing::Vector{Float64} = Float64[Float64(s) for s in voxel_spacing_input]
+    if length(spacing) > 3
+        throw(ArgumentError("voxel_spacing_input is too long! It should have 2 or 3 elements."))
+    elseif length(spacing) < 2
+        throw(ArgumentError("voxel_spacing_input is too short! It should have 2 or 3 elements."))
+    end
+
+    # Convert features (supports String, Vector{String}, Symbol, Vector{Symbol})
+    features_out::Vector{Symbol} = if features isa String
+        lowercase(features) == "all" ? Symbol[] : [Symbol(lowercase(features))]
+    elseif features isa AbstractVector && !isempty(features) && eltype(features) <: AbstractString
+        Symbol[Symbol(lowercase(string(f))) for f in features]
+    elseif features isa AbstractVector && !isempty(features) && !(eltype(features) <: Symbol)
+        Symbol[Symbol(lowercase(string(f))) for f in features]
+    else
+        Vector{Symbol}(features)
+    end
+
+    # Convert labels (supports Int, Vector{Int})
+    labels_out::Union{Int,Vector{Int}} = if labels isa AbstractVector
+        Int[Int(l) for l in labels]
+    elseif !isnothing(labels) && !(labels isa Int)
+        Int(labels)
+    elseif isnothing(labels)
+        Int(1)
+    else
+        Int(labels)
+    end
+
+    # Convert n_bins 
+    n_bins_out::Union{Nothing,Int} = isnothing(n_bins) ? nothing : Int(n_bins)
+
+    # Convert bin_width
+    bin_width_out::Union{Nothing,Float64} = isnothing(bin_width) ? nothing : Float64(bin_width)
+
+    # Convert weighting_norm
+    weighting_norm_out::Union{Nothing,String} = isnothing(weighting_norm) ? nothing : String(weighting_norm)
+
+    #Convert slices_2d
+    slices_2d_out::Union{Nothing, Vector{Tuple{Int,Int}}} = if isnothing(slices_2d)
+        nothing
+    else
+        Tuple{Int,Int}[(Int(s[1]), Int(s[2])) for s in slices_2d]
+    end
+
+    return (
+        img            = img,
+        mask           = mask,
+        spacing        = spacing,
+        features       = features_out,
+        labels         = labels_out,
+        n_bins         = n_bins_out,
+        bin_width      = bin_width_out,
+        weighting_norm = weighting_norm_out,
+        slices_2d      = slices_2d_out,
+        keep_largest_only = Bool(keep_largest_only),
+        get_raw_matrices  = Bool(get_raw_matrices),
+        verbose           = Bool(verbose)
+    )
 end
 
 """

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,4 +1,53 @@
 """
+    bounding_box(img, mask, verbose::Bool)
+
+    Computes the bounding box of a binary mask and crops both the image and the mask
+    to the smallest region containing all voxels where `mask == 1`.
+    Works for both 2D and 3D arrays.
+
+    # Arguments
+    - `img`: The input image (2D or 3D array).
+    - `mask`: The binary mask defining the region of interest (same shape as `img`).
+    - `verbose`: If `true`, prints the original and cropped sizes with reduction percentage.
+
+    # Returns
+    - `cropped_img`: image array cropped to the bounding box of the mask.
+    - `cropped_mask`: binary mask array (`BitArray`) cropped to the same bounding box."""
+function bounding_box(img, mask, verbose::Bool)
+    if verbose
+        println("Calculating the bounding box")
+        println("Image data: $(size(img)) | $(prod(size(img))) voxels\nMask data: $(size(mask)) | $(count(mask .== 1)) voxels")
+    end
+
+    idx = findall(mask .== 1)
+    n = ndims(mask)
+
+    mins = [typemax(Int) for _ in 1:n]
+    maxs = [typemin(Int) for _ in 1:n]
+
+    for i in idx
+        for d in 1:n
+            if i[d] < mins[d]; mins[d] = i[d]; end
+            if i[d] > maxs[d]; maxs[d] = i[d]; end
+        end
+    end
+
+    ranges = [mins[d]:maxs[d] for d in 1:n]
+
+    cropped_img  = img[ranges...]
+    cropped_mask = mask[ranges...]
+
+    if verbose
+        img_size = size(cropped_img)
+        ct_voxels = prod(img_size)
+        image_crop_perc = 100 - prod(img_size) / prod(size(img)) * 100
+        println("Cropped image data: $img_size | $ct_voxels voxels | $(round(image_crop_perc, digits=2))% reduction ")
+    end
+
+    return cropped_img, BitArray(cropped_mask)
+end
+
+"""
     label_components(mask::AbstractArray{Bool})
 
     Labels connected components in a binary mask using 26-connectivity for 3D
@@ -361,11 +410,11 @@ function prepare_inputs(img_input::AbstractArray,
     if ndims(img_input) == 2
         # 2D input: convert to 2D Float64 array
         img = convert(Array{Float64,2}, img_input)   
-        mask = BitArray(mask_input .!= 0.0)           
+        mask = convert(Array{Int,2}, mask_input)           
     elseif ndims(img_input) == 3
         # 3D input: convert to 3D Float64 array
         img = convert(Array{Float64,3}, img_input)   
-        mask = BitArray(mask_input .!= 0.0)
+        mask = convert(Array{Int,3}, mask_input)
     else
         throw(ArgumentError("Input image must be 2D or 3D, got $(ndims(img_input))D"))
     end

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -233,28 +233,6 @@ function discretize_image(img::AbstractArray{Float64},
 end
 
 """
-    get_neighbors(idx::Int,
-                   dims::NTuple{N,Int} where N)::Vector{Int}
-
-    Gets the 26-connected neighbors of a voxel in a 3D image.
-
-    # Arguments
-    - `idx`: The linear index of the voxel.
-    - `dims`: The dimensions of the image.
-
-    # Returns
-    - A vector of linear indices of the neighbors.
-    """
-@inline function get_neighbors(idx::Int,
-                                dims::NTuple{N,Int} where N)::Vector{Int}
-    n = ndims(CartesianIndices(dims))
-    max_neighbors = 3^n - 1  # 8 per 2D, 26 per 3D
-    neighbors = Vector{Int}(undef, max_neighbors)
-    count = get_neighbors!(neighbors, idx, dims)
-    return resize!(neighbors, count)
-end
-
-"""
     keep_largest_component(mask::AbstractArray{Bool})::Tuple{AbstractArray{Bool}, Int}
 
     Keeps only the largest connected component in the binary mask. All other components are removed. 

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -136,10 +136,12 @@ function label_components(mask::AbstractArray{Bool})::Array{Int}
 end
 
 """
-    discretize_image(img::AbstractArray{Float64},
-                     mask::BitArray;
-                     n_bins::Union{Int,Nothing}=nothing,
-                     bin_width::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
+    function discretize_image(img::AbstractArray{Float64},
+                               mask::BitArray;
+                               n_bins::Union{Int,Nothing}=nothing,
+                               bin_width::Union{Float64,Nothing}=nothing,
+                               vmin::Union{Float64,Nothing}=nothing,
+                               vmax::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
 
     Discretizes the input image for radiomics feature calculation. 
     Takes into account only the voxels within the provided mask.
@@ -174,30 +176,28 @@ end
         disc, n_bins, levels, bw = discretize_image(img, mask)
     """
 function discretize_image(img::AbstractArray{Float64},
-                            mask::BitArray;
-                            n_bins::Union{Int,Nothing}=nothing,
-                            bin_width::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
+    mask::BitArray;
+    n_bins::Union{Int,Nothing}=nothing,
+    bin_width::Union{Float64,Nothing}=nothing,
+    vmin::Union{Float64,Nothing}=nothing,
+    vmax::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
 
-    # Convert to Float64 for backward compatibility
-    img_f64 = convert(Array{Float64}, img)
-    bin_width_f64 = isnothing(bin_width) ? nothing : Float64(bin_width)
-
-    # Early check for empty mask
     if sum(mask) == 0
-        return zeros(Int, size(img_f64)), 0, Int[], 0.0
+        return zeros(Int, size(img)), 0, Int[], 0.0
     end
 
-    # Compute min/max from masked values
-    vals = view(img_f64, mask)
-    vmin = minimum(vals)
-    vmax = maximum(vals)
+    if isnothing(vmin) || isnothing(vmax)
+        vals = view(img, mask)
+        vmin = minimum(vals)
+        vmax = maximum(vals)
+    end
 
-    disc = zeros(Int, size(img_f64))
+    disc = zeros(Int, size(img))
 
-    if !isnothing(n_bins) && !isnothing(bin_width_f64)
+    if !isnothing(n_bins) && !isnothing(bin_width)
         error("Specify either n_bins or bin_width, not both.")
-    elseif isnothing(n_bins) && isnothing(bin_width_f64)
-        bin_width_f64 = 25.0
+    elseif isnothing(n_bins) && isnothing(bin_width)
+        bin_width = 25.0
     end
 
     if !isnothing(n_bins)
@@ -205,24 +205,21 @@ function discretize_image(img::AbstractArray{Float64},
         if bin_width_used ≈ 0.0
             bin_width_used = 1.0
         end
-
         inv_bin_width = 1.0 / bin_width_used
-        # Iterate directly using linear indices without allocating index array
         @inbounds for i in eachindex(mask)
             if mask[i]
-                v = img_f64[i]
+                v = img[i]
                 b = min(Int(floor((v - vmin) * inv_bin_width)) + 1, n_bins)
                 disc[i] = b
             end
         end
     else
-        bin_width_used = bin_width_f64
+        bin_width_used = bin_width  # già Float64
         inv_bin_width = 1.0 / bin_width_used
         bin_offset = Int(floor(vmin * inv_bin_width))
-
         @inbounds for i in eachindex(mask)
             if mask[i]
-                v = img_f64[i]
+                v = img[i]
                 b = Int(floor(v * inv_bin_width)) - bin_offset + 1
                 disc[i] = b
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,7 @@ mktempdir() do tmpdir
         mask = niread(mask_path)
         spacing = [ct.header.pixdim[2], ct.header.pixdim[3], ct.header.pixdim[4]]
 
-        radiomic_2D_features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose=false, n_bins = 6, keep_largest_only=false, slices_2d = [[3,3]])
+        radiomic_2D_features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose=false, n_bins = 6, keep_largest_only=false, slices_2d = [(3,3)])
         
         # ---- First Order ---- (19 features)
         @test ibsi_test(radiomic_2D_features["firstorder_entropy"], 0.8343470230852528, 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ mktempdir() do tmpdir
         mask = niread(mask_path)
         spacing = [ct.header.pixdim[2], ct.header.pixdim[3], ct.header.pixdim[4]]
 
-        radiomic_features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose=false, sample_rate = 1.0, n_bins = 6, keep_largest_only=false)
+        radiomic_features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose=false, n_bins = 6, keep_largest_only=false)
 
         # ---- First Order ---- (19 features)
         @test ibsi_test(radiomic_features["firstorder_entropy"], 1.27, 0)
@@ -207,7 +207,7 @@ mktempdir() do tmpdir
         mask = niread(mask_path)
         spacing = [ct.header.pixdim[2], ct.header.pixdim[3], ct.header.pixdim[4]]
 
-        radiomic_2D_features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose=false, sample_rate = 1.0, n_bins = 6, keep_largest_only=false, slices_2d = [[3,3]])
+        radiomic_2D_features = Radiomics.extract_radiomic_features(ct.raw, mask.raw, spacing; verbose=false, n_bins = 6, keep_largest_only=false, slices_2d = [[3,3]])
         
         # ---- First Order ---- (19 features)
         @test ibsi_test(radiomic_2D_features["firstorder_entropy"], 0.8343470230852528, 0)


### PR DESCRIPTION
refactor: introduce type barrier pattern and centralize input validation

Core architecture changes:
- Add _cast_inputs() as dedicated type barrier function that converts all untyped
  inputs to concrete Julia types before feature extraction begins
- Remove prepare_inputs() — its responsibilities are now fully absorbed by _cast_inputs()
- Remove input_sanity_check() — size validation is now implicit via prepare_inputs removal
  and type system guarantees from _cast_inputs()
- extract_radiomic_features() is now a clean entry point: casts via _cast_inputs(),
  then delegates to the typed pipeline using p.img, p.mask, p.spacing, etc.

Performance optimizations:
- Add type annotations to all public function signatures (get_glcm_features,
  get_first_order_features, get_shape3d_features, get_shape2d_features,
  get_glszm_features, get_ngtdm_features, get_glrlm_features, get_gldm_features)
- Add ::Dict{String,Any} and ::Float64 return type annotations to internal functions
- Fix ::Nothing return type on print_features and print_features_diagnosis
  (append! returns Vector, not Nothing — caused precompilation failure)
- Optimize GLCM: pre-allocate GLCMBuffer once for all 13 directions, avoiding
  repeated px/py/p_xminusy/p_xplusy allocations per direction
- Optimize GLCM: replace enumerate(c_dirs) with direct index 1:n_dirs
- Fix GLCM symmetrization bug: reflect upper triangle was overwriting instead
  of summing — now symmetrized inline during fill
- Fix GLCM interior/border split: CartesianIndex{3} was hardcoded, breaking 2D;
  now uses eltype(mask_indices)
- Optimize first_order: single sort() replaces two separate scans (percentile + min/max)
- Optimize first_order: pass vmin/vmax to discretize_image() to avoid redundant
  min/max scan inside discretize_image
- Add optional vmin/vmax parameters to discretize_image() signature
- Optimize NGTDM: replace get_neighbors!() with direct CartesianIndex offsets,
  interior/border split, and Array lookup instead of Dict for gl_map
- Optimize NGTDM: replace N×N matrix broadcasting in contrast/busyness/complexity/
  strength with explicit @inbounds loops — eliminates temporary matrix allocations
- Optimize GLSZM: same interior/border split and Array lookup as NGTDM
- Optimize GLSZM: replace reshape/broadcasting in 4 combined emphasis features
  with explicit @inbounds loops
- Optimize 2D shape: move LINE_TABLE_2D, VERT_LIST_2D, GRID_ANGLES_2D,
  POINTS_EDGES_2D to module-level const — allocated once at load, not per call
- Optimize 2D shape: replace Vector{Float64} allocations in get_coefficients
  inner loop with scalar variables a1/a2/b1/b2
- Optimize 2D shape: rewrite get_eigenvalues() replacing Iterators.filter and
  list comprehension with direct @inbounds loop
- Add @inbounds to marching_cubes_surface outer loop
- Optimize maximum_3d_diameter: replace Set deduplication with Vector + unique!()

Precompilation:
- Expand @compile_workload to cover all major code paths: default bin_width,
  n_bins, explicit bin_width, all 4 weighting norms, 9 selective feature
  combinations, keep_largest_only=true, multi-label, single label,
  get_raw_matrices, single slice and multiple slices via slices_2d
- Fix Union return type of extract_radiomic_features to include
  Dict{Tuple{Int,Int},Any} for slices_2d case (was causing precompilation failure)
-Expand 2D also.

Log output:
- Clean verbose log visualization: multi-label logs now buffered per label
  and printed in order after all tasks complete
- Add @warn sprint(showerror, e, catch_backtrace()) in multi-label catch block
  for full stacktrace on error

Tests:
- All 210 tests passing (106 3D + 104 2D)