### PR TITLE
Alternative feature calculation

### DIFF
--- a/docs/example.html
+++ b/docs/example.html
@@ -699,6 +699,7 @@ spacing = [ct.header.pixdim[<span class="julia-literal">2</span>], ct.header.pix
 features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; <span class="julia-literal">labels=1</span>);</code></pre>
                 </div>
             </div>
+
             <!-- SNIPPET 5 -->
             <div class="section">
                 <h3>Select list of labels</h3>
@@ -723,6 +724,7 @@ features = <span class="julia-type">Radiomics</span>.<span class="julia-function
                     11).
                 </p>
             </div>
+
             <!-- SNIPPET 6 -->
             <div class="section">
                 <h3>Extraction with a specific bin_width </h3>
@@ -744,6 +746,30 @@ spacing = [ct.header.pixdim[<span class="julia-literal">2</span>], ct.header.pix
 features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; features=[:first_order, :glcm], <span class="julia-literal">bin_width=35</span>);</code></pre>
                 </div>
             </div>
+
+            <!-- SNIPPET std -->
+            <div class="section">
+                <h3>Standard Deviation Calculation</h3>
+                <p>The following example shows how to calculate the standard deviation from the extracted texture
+                    features:</p>
+
+                <div class="code-container">
+                    <div class="code-header">
+                        <span class="code-dot"></span>
+                        <span class="code-dot"></span>
+                        <span class="code-dot"></span>
+                    </div>
+                    <pre><code><span class="julia-keyword">using</span> <span class="julia-type">NIfTI</span>
+<span class="julia-keyword">using</span> <span class="julia-type">Radiomics</span>
+
+ct   = <span class="julia-function">niread</span>(<span class="julia-string">"sample_data/CTChest.nii.gz"</span>)
+mask = <span class="julia-function">niread</span>(<span class="julia-string">"sample_data/Lungs.nii.gz"</span>)
+spacing = [ct.header.pixdim[<span class="julia-literal">2</span>], ct.header.pixdim[<span class="julia-literal">3</span>], ct.header.pixdim[<span class="julia-literal">4</span>]]
+
+features = <span class="julia-type">Radiomics</span>.<span class="julia-function">extract_radiomic_features</span>(ct.raw, mask.raw, spacing; <span class="julia-literal">features_std = true</span>);</code></pre>
+                </div>
+            </div>
+
             <!-- SNIPPET 7 -->
             <div class="section">
                 <h3>Extraction with a specific n_bins</h3>

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -226,7 +226,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                     diagnosis_features = get_diagnosis_features(
                         p.bin_width, p.spacing, total_time_real,
                         p.weighting_norm, p.n_bins, p.keep_largest_only,
-                        p.img, img_to_use, p.mask, mask_to_use
+                        p.img, p.features_std, img_to_use, p.mask, mask_to_use
                     )
                     merge!(radiomic_features, diagnosis_features)
 
@@ -342,7 +342,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         diagnosis_features = get_diagnosis_features(
             p.bin_width, p.spacing, total_time_real,
             p.weighting_norm, p.n_bins, p.keep_largest_only,
-            p.img, img_to_use, p.mask, mask_to_use
+            p.img, p.features_std, img_to_use, p.mask, mask_to_use
         )
         merge!(radiomic_features, diagnosis_features)
         print_features_diagnosis("Diagnosis Features", diagnosis_features)

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -62,6 +62,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     weighting_norm=nothing,
     keep_largest_only::Bool=true,
     get_raw_matrices::Bool=false,
+    features_std::Bool=false,
     slices_2d=nothing,
     verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}, Dict{Tuple{Int,Int},Any}}
 
@@ -75,6 +76,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         n_bins,
         bin_width,
         weighting_norm,
+        features_std,
         slices_2d,
         keep_largest_only,
         get_raw_matrices,
@@ -132,6 +134,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 n_bins            = p.n_bins,
                 bin_width         = p.bin_width,
                 weighting_norm    = p.weighting_norm,
+                features_std      = p.features_std,
                 keep_largest_only = p.keep_largest_only,
                 get_raw_matrices  = p.get_raw_matrices,
                 verbose           = p.verbose
@@ -206,6 +209,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                         verbose           = p.verbose,
                         keep_largest_only = p.keep_largest_only,
                         compute_all       = compute_all,
+                        features_std      = p.features_std,
                         features          = p.features,
                         get_raw_matrices  = p.get_raw_matrices,
                         log_buffer        = log_buffer
@@ -321,6 +325,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         weighting_norm    = p.weighting_norm,
         verbose           = p.verbose,
         keep_largest_only = p.keep_largest_only,
+        features_std      = p.features_std,
         compute_all       = compute_all,
         features          = p.features,
         get_raw_matrices  = p.get_raw_matrices
@@ -385,6 +390,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
     verbose::Bool=false,
     keep_largest_only::Bool=true,
     compute_all::Bool=true,
+    features_std::Bool=false,
     features::Vector{Symbol}=Symbol[],
     get_raw_matrices::Bool=false,
     log_buffer::Union{Nothing,Vector{String}}=nothing)::Tuple{Dict{String,Any}, Float64}
@@ -424,6 +430,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
                 n_bins=n_bins,
                 bin_width=bin_width,
                 weighting_norm=weighting_norm,
+                features_std=features_std,
                 get_raw_matrices=get_raw_matrices,
                 verbose=verbose
             )
@@ -479,6 +486,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
                 img, mask, voxel_spacing;
                 n_bins=n_bins,
                 bin_width=bin_width,
+                features_std=features_std,
                 weighting_norm=weighting_norm,
                 get_raw_matrices=get_raw_matrices,
                 verbose=verbose
@@ -783,6 +791,15 @@ end
         extract_radiomic_features(
             img_small, mask_small, spacing;
             keep_largest_only = true,
+            verbose           = false
+        )
+
+        # --- features_std = true ---
+        extract_radiomic_features(
+            img_small, mask_small, spacing;
+            features          = [:glrlm],
+            features_std      = true,
+            keep_largest_only = false,
             verbose           = false
         )
 

--- a/src/diagnostic_features.jl
+++ b/src/diagnostic_features.jl
@@ -41,6 +41,7 @@ function get_diagnosis_features(bin_width::Union{Float64,Nothing},
                                  n_bins::Union{Int,Nothing},
                                  keep_largest_only::Bool,
                                  image_input::AbstractArray,
+                                 features_std::Bool,
                                  img_to_use::AbstractArray,
                                  mask_input::AbstractArray,
                                  mask_to_use::AbstractArray)::Dict{String,Any}
@@ -59,6 +60,7 @@ function get_diagnosis_features(bin_width::Union{Float64,Nothing},
     diagnosis_features["diagnosis_Number_of_bins"] = isnothing(n_bins) ? 32 : n_bins
     diagnosis_features["diagnosis_Weighting_norm"] = isnothing(weighting_norm) ? "no_weighting" : weighting_norm
     diagnosis_features["diagnosis_Keep_largest_only"] = keep_largest_only
+    diagnosis_features["diagnosis_Features_std"] = features_std
     
     # Parameters of the image
     diagnosis_features["diagnosis_Voxel_spacing"] = collect(voxel_spacing)

--- a/src/glcm_features.jl
+++ b/src/glcm_features.jl
@@ -435,6 +435,7 @@ function get_glcm_features(img::AbstractArray{Float64},
                             n_bins::Union{Int,Nothing}=nothing,
                             bin_width::Union{Float64,Nothing}=nothing,
                             weighting_norm::Union{String,Nothing}=nothing,
+                            features_std::Bool=false,
                             get_raw_matrices::Bool=false,
                             verbose::Bool=false)::Dict{String,Any}
 
@@ -463,22 +464,42 @@ function get_glcm_features(img::AbstractArray{Float64},
     inv_n = 1.0 / Float64(n_matrices)
     
     final_features = Dict{String, Any}()
-
+    sums_sq = Dict{String, Float64}()
+    mins    = Dict{String, Float64}()
+    maxs    = Dict{String, Float64}()
 
     f1 = extract_glcm_features(glcm_matrices[1], gray_levels)
     for (name, val) in f1
         final_features[name] = val
+        if features_std
+            sums_sq[name] = val^2
+            mins[name] = val
+            maxs[name] = val
+        end
     end
 
     @inbounds for k in 2:n_matrices
         f = extract_glcm_features(glcm_matrices[k], gray_levels)
         for (name, val) in f
             final_features[name] += val
+            if features_std
+                sums_sq[name] += val^2
+                if val < mins[name]; mins[name] = val; end
+                if val > maxs[name]; maxs[name] = val; end
+            end
         end
     end
 
-    for (name, val) in final_features
-        final_features[name] = val * inv_n
+    for name in collect(keys(final_features))
+        mean_val = final_features[name] * inv_n
+        final_features[name] = mean_val
+
+        if features_std
+            variance = max(sums_sq[name] * inv_n - mean_val^2, 0.0)
+            final_features[name*"_std"] = sqrt(variance)
+            final_features[name*"_min"] = mins[name]
+            final_features[name*"_max"] = maxs[name]
+        end
     end
 
     verbose && println("Completed! Extracted $(length(final_features)) features.")

--- a/src/glrlm_features.jl
+++ b/src/glrlm_features.jl
@@ -12,6 +12,7 @@ function get_glrlm_features(img::AbstractArray{Float64},
                              bin_width::Union{Float64,Nothing}=nothing,
                              weighting_norm::Union{String,Nothing}=nothing,
                              get_raw_matrices::Bool=false,
+                             features_std::Bool=false,
                              verbose::Bool=false)::Dict{String,Any}
     
     if verbose
@@ -24,6 +25,9 @@ function get_glrlm_features(img::AbstractArray{Float64},
         end
         if !isnothing(weighting_norm)
             println("Applying weighting: $(weighting_norm)")
+        end
+        if features_std
+            println("Computing std across angles: enabled")
         end
     end
 
@@ -56,7 +60,7 @@ function get_glrlm_features(img::AbstractArray{Float64},
         "LongRunHighGrayLevelEmphasis"
     ]
 
-    extracted_features = extract_all_glrlm_features(P_glrlm, gray_levels, feature_names)
+    extracted_features = extract_all_glrlm_features(P_glrlm, gray_levels, feature_names; features_std=features_std)
     merge!(glrlm_features, extracted_features)
 
     if verbose
@@ -190,24 +194,35 @@ end
 
     Extracts all features via a high-performance single-pass, flat 2D loop.
     Skips empty rows/columns and eliminates nested generator heap allocations.
+
+    If `features_std=true`, also computes the standard deviation of each feature
+    across angles, stored as "glrlm_<FeatureName>_std".
+    Note: when weighting_norm is used, num_angles == 1 so std will be 0 for all features.
 """
 function extract_all_glrlm_features(P_glrlm::Array{Float64,3},
                                      gray_levels::Vector{Int},
-                                     feature_names::Vector{String})::Dict{String,Any}
-    num_gl = length(gray_levels)
+                                     feature_names::Vector{String};
+                                     features_std::Bool=false)::Dict{String,Any}
+    num_gl         = length(gray_levels)
     max_run_length = size(P_glrlm, 2)
-    num_angles = size(P_glrlm, 3)
-    num_features = length(feature_names)
-    
-    feature_sums = zeros(Float64, num_features)
+    num_angles     = size(P_glrlm, 3)
+    num_features   = length(feature_names)
 
-    ivector = Float64.(gray_levels)
-    jvector = Float64.(1:max_run_length)
+    feature_sums    = zeros(Float64, num_features)
+    feature_sums_sq = zeros(Float64, num_features)  # used only when features_std=true
+    feature_min     = fill(Inf, num_features)   
+    feature_max     = fill(-Inf, num_features)
+
+    ivector    = Float64.(gray_levels)
+    jvector    = Float64.(1:max_run_length)
     ivector_sq = ivector .^ 2
     jvector_sq = jvector .^ 2
 
     pr = zeros(Float64, 1, max_run_length)
     pg = zeros(Float64, num_gl, 1)
+
+    # Temporary buffer for per-angle feature values (allocated once, reused)
+    angle_vals = zeros(Float64, num_features)
 
     @inbounds for a in 1:num_angles
         p_slice = @view P_glrlm[:, :, a]
@@ -216,87 +231,109 @@ function extract_all_glrlm_features(P_glrlm::Array{Float64,3},
             continue
         end
 
-        inv_Nr = 1.0 / Nr
+        fill!(angle_vals, 0.0)  # reset per-angle buffer
+
+        inv_Nr    = 1.0 / Nr
         inv_Nr_sq = inv_Nr * inv_Nr
 
         sum!(pr, p_slice)
         sum!(pg, p_slice)
 
-        # 1D Vector Optimization: Run Length metrics (j-dependent)
-        Np = 0.0
+        # 1D: Run Length metrics (j-dependent)
+        Np      = 0.0
         u_j_sum = 0.0
         for j in 1:max_run_length
             if pr[j] > 0.0
                 j_sq = jvector_sq[j]
                 pr_j = pr[j]
-                
-                feature_sums[1] += (pr_j / j_sq) * inv_Nr               # ShortRunEmphasis
-                feature_sums[2] += (pr_j * j_sq) * inv_Nr               # LongRunEmphasis
-                feature_sums[5] += (pr_j^2) * inv_Nr                    # RunLengthNonUniformity
-                feature_sums[6] += (pr_j^2) * inv_Nr_sq                 # RunLengthNonUniformityNormalized
-                
-                Np += pr_j * jvector[j]
+
+                angle_vals[1] += (pr_j / j_sq) * inv_Nr          # ShortRunEmphasis
+                angle_vals[2] += (pr_j * j_sq) * inv_Nr           # LongRunEmphasis
+                angle_vals[5] += (pr_j^2) * inv_Nr                # RunLengthNonUniformity
+                angle_vals[6] += (pr_j^2) * inv_Nr_sq             # RunLengthNonUniformityNormalized
+
+                Np      += pr_j * jvector[j]
                 u_j_sum += pr_j * jvector[j]
             end
         end
-        
+
         if Np > 0.0
-            feature_sums[7] += Nr / Np                                  # RunPercentage
+            angle_vals[7] += Nr / Np                              # RunPercentage
         end
 
-        # 1D Vector Optimization: Gray Level metrics (g-dependent)
+        # 1D: Gray Level metrics (g-dependent)
         u_i_sum = 0.0
         for g in 1:num_gl
             if pg[g] > 0.0
-                i_sq = ivector_sq[g]
-                pg_g = pg[g]
-                
-                feature_sums[3] += (pg_g^2) * inv_Nr                    # GrayLevelNonUniformity
-                feature_sums[4] += (pg_g^2) * inv_Nr_sq                 # GrayLevelNonUniformityNormalized
-                feature_sums[11] += (pg_g / i_sq) * inv_Nr              # LowGrayLevelRunEmphasis
-                feature_sums[12] += (pg_g * i_sq) * inv_Nr              # HighGrayLevelRunEmphasis
-                
+                i_sq  = ivector_sq[g]
+                pg_g  = pg[g]
+
+                angle_vals[3]  += (pg_g^2) * inv_Nr               # GrayLevelNonUniformity
+                angle_vals[4]  += (pg_g^2) * inv_Nr_sq            # GrayLevelNonUniformityNormalized
+                angle_vals[11] += (pg_g / i_sq) * inv_Nr          # LowGrayLevelRunEmphasis
+                angle_vals[12] += (pg_g * i_sq) * inv_Nr          # HighGrayLevelRunEmphasis
+
                 u_i_sum += pg_g * ivector[g]
             end
         end
 
-        # Variance profiles 
+        # Variance profiles
         u_j = u_j_sum * inv_Nr
         u_i = u_i_sum * inv_Nr
         for j in 1:max_run_length
             if pr[j] > 0.0
-                feature_sums[9] += pr[j] * inv_Nr * (jvector[j] - u_j)^2 # RunVariance
+                angle_vals[9] += pr[j] * inv_Nr * (jvector[j] - u_j)^2  # RunVariance
             end
         end
         for g in 1:num_gl
             if pg[g] > 0.0
-                feature_sums[8] += pg[g] * inv_Nr * (ivector[g] - u_i)^2 # GrayLevelVariance
+                angle_vals[8] += pg[g] * inv_Nr * (ivector[g] - u_i)^2  # GrayLevelVariance
             end
         end
 
-        # Unified 2D loop over non-zero values (Column-major iteration for cache locality)
+        # Unified 2D loop (column-major for cache locality)
         for j in 1:max_run_length
             j_sq = jvector_sq[j]
             for g in 1:num_gl
-                p_val = p_slice[g,j]
+                p_val = p_slice[g, j]
                 if p_val > 0.0
                     i_sq = ivector_sq[g]
                     prob = p_val * inv_Nr
-                    
-                    feature_sums[10] += -prob * log2(prob + 1e-16)              # RunEntropy
-                    feature_sums[13] += (p_val / (i_sq * j_sq)) * inv_Nr        # ShortRunLowGrayLevelEmphasis
-                    feature_sums[14] += (p_val * i_sq / j_sq) * inv_Nr          # ShortRunHighGrayLevelEmphasis
-                    feature_sums[15] += (p_val * j_sq / i_sq) * inv_Nr          # LongRunLowGrayLevelEmphasis
-                    feature_sums[16] += (p_val * i_sq * j_sq) * inv_Nr          # LongRunHighGrayLevelEmphasis
+
+                    angle_vals[10] += -prob * log2(prob + 1e-16)              # RunEntropy
+                    angle_vals[13] += (p_val / (i_sq * j_sq)) * inv_Nr        # ShortRunLowGrayLevelEmphasis
+                    angle_vals[14] += (p_val * i_sq / j_sq) * inv_Nr          # ShortRunHighGrayLevelEmphasis
+                    angle_vals[15] += (p_val * j_sq / i_sq) * inv_Nr          # LongRunLowGrayLevelEmphasis
+                    angle_vals[16] += (p_val * i_sq * j_sq) * inv_Nr          # LongRunHighGrayLevelEmphasis
                 end
+            end
+        end
+
+        # Accumulate into global sums
+        @inbounds for i in 1:num_features
+            feature_sums[i] += angle_vals[i]
+            if features_std
+                feature_sums_sq[i] += angle_vals[i]^2
+                if angle_vals[i] < feature_min[i]; feature_min[i] = angle_vals[i]; end
+                if angle_vals[i] > feature_max[i]; feature_max[i] = angle_vals[i]; end
             end
         end
     end
 
-    inv_angles = 1.0 / num_angles
+    inv_angles     = 1.0 / num_angles
     glrlm_features = Dict{String,Any}()
+
     for (idx, name) in enumerate(feature_names)
-        glrlm_features["glrlm_"*name] = feature_sums[idx] * inv_angles
+        mean_val = feature_sums[idx] * inv_angles
+        glrlm_features["glrlm_"*name] = mean_val
+
+        if features_std
+            # Var(X) = E[X²] - E[X]²  — clamped to 0 to avoid -epsilon from float rounding
+            variance = max(feature_sums_sq[idx] * inv_angles - mean_val^2, 0.0)
+            glrlm_features["glrlm_"*name*"_std"] = sqrt(variance)
+            glrlm_features["glrlm_"*name*"_min"] = feature_min[idx]   # <-- aggiunto
+            glrlm_features["glrlm_"*name*"_max"] = feature_max[idx] 
+        end
     end
 
     return glrlm_features

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -323,11 +323,29 @@ function print_features(title::String,
     output = String[]
     
     push!(output, "\n--- $title ---")
-    sorted_keys = sort(collect(keys(features)))
-    for (i, k) in enumerate(sorted_keys)
-        push!(output, "  $i. $(rpad(k, 35)) => $(features[k])")
+    
+    base_keys = sort([k for k in keys(features) 
+                       if !endswith(k, "_std") && !endswith(k, "_min") && !endswith(k, "_max")])
+    
+    for (i, k) in enumerate(base_keys)
+        val = features[k]
+        std_key = k * "_std"
+        min_key = k * "_min"
+        max_key = k * "_max"
+        
+        padded_key = rpad(k, 42)
+        
+        if haskey(features, std_key)
+            std_val = features[std_key]
+            min_val = features[min_key]
+            max_val = features[max_key]
+            push!(output, "  $i. $(padded_key) => $val (std = $std_val, min = $min_val, max = $max_val)")
+        else
+            push!(output, "  $i. $(padded_key) => $val")
+        end
     end
-    push!(output, "Subtotal: $(length(features)) features")
+    
+    push!(output, "Subtotal: $(length(base_keys)) features")
     push!(output, "---------------------\n")
     
     if isnothing(log_buffer)
@@ -360,12 +378,13 @@ function _cast_inputs(
     n_bins,
     bin_width,
     weighting_norm,
+    features_std,
     slices_2d,          
     keep_largest_only,  
     get_raw_matrices,   
     verbose             
     )::NamedTuple{
-        (:img, :mask, :spacing, :features, :labels, :n_bins, :bin_width, :weighting_norm, :slices_2d, :keep_largest_only, :get_raw_matrices, :verbose),
+        (:img, :mask, :spacing, :features, :labels, :n_bins, :bin_width, :weighting_norm, :features_std, :slices_2d, :keep_largest_only, :get_raw_matrices, :verbose),
         Tuple{
             Union{Array{Float64,2}, Array{Float64,3}},
             Union{Array{Int,2}, Array{Int,3}},
@@ -375,6 +394,7 @@ function _cast_inputs(
             Union{Nothing, Int},
             Union{Nothing, Float64},
             Union{Nothing, String}, 
+            Bool,
             Union{Nothing, Vector{Tuple{Int,Int}}},
             Bool,                                     
             Bool,                                     
@@ -470,6 +490,7 @@ function _cast_inputs(
         n_bins         = n_bins_out,
         bin_width      = bin_width_out,
         weighting_norm = weighting_norm_out,
+        features_std   = Bool(features_std),
         slices_2d      = slices_2d_out,
         keep_largest_only = Bool(keep_largest_only),
         get_raw_matrices  = Bool(get_raw_matrices),


### PR DESCRIPTION
## Add `features_std` parameter for directional feature statistics

Adds a new boolean parameter `features_std` to `extract_radiomic_features`, enabling the computation of per-direction statistics (standard deviation, min, max) for feature families that aggregate over multiple directional matrices.

### Motivation

GLCM and GLRLM features are computed independently for each direction (13 and 26 directions in 3D respectively) and then averaged. The mean alone discards directional variability that may carry relevant radiomic information. With `features_std=true`, each feature is reported as mean ± std with min/max across directions, providing a richer representation at the cost of a larger feature vector.

### Changes

**`glrlm_features.jl`**
- Added `features_std::Bool=false` to `get_glrlm_features` and `extract_all_glrlm_features`
- Restructured the inner angle loop to compute per-angle feature values into a temporary buffer (`angle_vals`), then accumulate into `feature_sums`, `feature_sums_sq`, `feature_min`, `feature_max`
- When `features_std=true`, adds `glrlm_<name>_std`, `glrlm_<name>_min`, `glrlm_<name>_max` to the output dict alongside the existing mean
- Variance computed as E[x²] − E[x]² with `max(..., 0.0)` guard against floating-point negatives

**`glcm_features.jl`**
- Added `features_std::Bool=false` to `get_glcm_features`
- Same accumulation pattern over `glcm_matrices`: auxiliary dicts `sums_sq`, `mins`, `maxs` populated per matrix, then std/min/max appended after the mean is finalized
- Keys iterated via `collect(keys(...))` before mutation to avoid modifying the dict during iteration

**`Radiomics.jl`**
- Added `features_std::Bool=false` to `extract_radiomic_features` and `_compute_radiomics_impl`
- Propagated through `_cast_inputs` (NamedTuple updated: key order, type tuple, return statement)
- Passed as `p.features_std` at all call sites: slices_2d recursive path, multi-label path, single-label path
- Forwarded to `get_glcm_features` and `get_glrlm_features` in their respective `Threads.@spawn` blocks

**`utils.jl`** (`print_features`)
- Updated to detect `_std`/`_min`/`_max` sibling keys and display them inline: `=> mean (std = ..., min = ..., max = ...)`
- Base key count (for the subtotal line) excludes `_std`/`_min`/`_max` keys

**`diagnostic_features.jl`**
- Added `features_std` to the signature of `get_diagnosis_features` and stored in the diagnosis dict

### Feature count impact

| Condition | GLRLM keys | GLCM keys |
|---|---|---|
| `features_std=false` (default) | 16 | unchanged |
| `features_std=true` | 64 (16 × mean/std/min/max) | 4× base count |

### Design decisions

- `features_std` is **not** applied to GLDM, NGTDM, or GLSZM — these families produce a single isotropic matrix, so there is no directional variability to measure
- When `weighting_norm` is set, both GLCM and GLRLM collapse to a single matrix (`num_angles=1`), so std/min/max will always be 0 — this is documented in the respective docstrings
- When `get_raw_matrices=true`, the early-return path is taken before any `features_std` logic, so raw matrix output is unaffected
- Default is `false` — fully backward compatible, no existing call sites require changes

### Tested on
- IBSI Digital Phantom (5×4×4 ROI, n_bins=6)
- Output verified: 64 GLRLM keys present, std/min/max values non-zero and consistent with per-direction spread