### PR TITLE
squeeze_unit_dimension

### DIFF
--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -183,6 +183,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 push!(log_buffer, "Applying bounding box to Label $label...")
                 local img_to_use
                 img_to_use, mask_to_use = bounding_box(p.img, mask_to_use, p.verbose; log_buffer=log_buffer)
+                img_to_use, mask_to_use, spacing_to_use = squeeze_singleton_dims(img_to_use, mask_to_use, p.spacing)
 
                 if compute_all
                     push!(log_buffer, "Computing ALL features")
@@ -203,7 +204,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                     total_time_accumulated = 0.0
 
                     radiomic_features, time_acc = _compute_radiomics_impl(
-                        img_to_use, mask_to_use, p.spacing, voxel_count;
+                        img_to_use, mask_to_use, spacing_to_use, voxel_count;
                         n_bins            = p.n_bins,
                         bin_width         = p.bin_width,
                         weighting_norm    = p.weighting_norm,
@@ -294,6 +295,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     end
 
     img_to_use, mask_to_use = bounding_box(p.img, mask_to_use, p.verbose)
+    img_to_use, mask_to_use, spacing_to_use = squeeze_singleton_dims(img_to_use, mask_to_use, p.spacing)
 
     total_start_time       = time()
     total_time_accumulated = 0.0
@@ -320,7 +322,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     end
 
     radiomic_features, time_acc = _compute_radiomics_impl(
-        img_to_use, mask_to_use, p.spacing, voxel_count;
+        img_to_use, mask_to_use, spacing_to_use, voxel_count;
         n_bins            = p.n_bins,
         bin_width         = p.bin_width,
         weighting_norm    = p.weighting_norm,

--- a/src/Radiomics.jl
+++ b/src/Radiomics.jl
@@ -65,7 +65,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     get_raw_matrices::Bool=false,
     features_std::Bool=false,
     slices_2d=nothing,
-    verbose::Bool=false)::Union{Dict{String,Any}, Dict{Int,Dict{String,Any}}, Dict{Tuple{Int,Int},Any}}
+    verbose::Bool=false)::Union{Dict{String,Any},Dict{Int,Dict{String,Any}},Dict{Tuple{Int,Int},Any}}
 
     # Cast all inputs to correct types
     p = _cast_inputs(
@@ -81,15 +81,15 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
         slices_2d,
         keep_largest_only,
         get_raw_matrices,
-        verbose  
+        verbose
     )
 
     compute_all = isempty(p.features) || :all in p.features
 
     # Management slices_2d
     if !isnothing(p.slices_2d)
-        results_2d = Dict{Tuple{Int,Int}, Any}()
-        dict_lock  = ReentrantLock()
+        results_2d = Dict{Tuple{Int,Int},Any}()
+        dict_lock = ReentrantLock()
 
         Threads.@threads for i in eachindex(p.slices_2d)
             plan, slice_idx = p.slices_2d[i]
@@ -130,15 +130,15 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
 
             result = extract_radiomic_features(
                 img_slice, mask_slice, spacing_2d;
-                features          = p.features,
-                labels            = p.labels,
-                n_bins            = p.n_bins,
-                bin_width         = p.bin_width,
-                weighting_norm    = p.weighting_norm,
-                features_std      = p.features_std,
-                keep_largest_only = p.keep_largest_only,
-                get_raw_matrices  = p.get_raw_matrices,
-                verbose           = p.verbose
+                features=p.features,
+                labels=p.labels,
+                n_bins=p.n_bins,
+                bin_width=p.bin_width,
+                weighting_norm=p.weighting_norm,
+                features_std=p.features_std,
+                keep_largest_only=p.keep_largest_only,
+                get_raw_matrices=p.get_raw_matrices,
+                verbose=p.verbose
             )
 
             lock(dict_lock) do
@@ -161,9 +161,9 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
             println("Active threads: ", Threads.nthreads())
         end
 
-        results        = Dict{Int, Dict{String,Any}}()
+        results = Dict{Int,Dict{String,Any}}()
         skipped_labels = Int[]
-        results_lock   = ReentrantLock()
+        results_lock = ReentrantLock()
 
         tasks = map(p.labels) do label
             Threads.@spawn let label = label
@@ -183,7 +183,7 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 push!(log_buffer, "Applying bounding box to Label $label...")
                 local img_to_use
                 img_to_use, mask_to_use = bounding_box(p.img, mask_to_use, p.verbose; log_buffer=log_buffer)
-                img_to_use, mask_to_use, spacing_to_use = squeeze_singleton_dims(img_to_use, mask_to_use, p.spacing)
+                img_to_use, mask_to_use, spacing_to_use = squeeze_unit_dimension(img_to_use, mask_to_use, p.spacing)
 
                 if compute_all
                     push!(log_buffer, "Computing ALL features")
@@ -200,25 +200,25 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
                 end
 
                 try
-                    total_start_time       = time()
+                    total_start_time = time()
                     total_time_accumulated = 0.0
 
                     radiomic_features, time_acc = _compute_radiomics_impl(
                         img_to_use, mask_to_use, spacing_to_use, voxel_count;
-                        n_bins            = p.n_bins,
-                        bin_width         = p.bin_width,
-                        weighting_norm    = p.weighting_norm,
-                        verbose           = p.verbose,
-                        keep_largest_only = p.keep_largest_only,
-                        compute_all       = compute_all,
-                        features_std      = p.features_std,
-                        features          = p.features,
-                        get_raw_matrices  = p.get_raw_matrices,
-                        log_buffer        = log_buffer
+                        n_bins=p.n_bins,
+                        bin_width=p.bin_width,
+                        weighting_norm=p.weighting_norm,
+                        verbose=p.verbose,
+                        keep_largest_only=p.keep_largest_only,
+                        compute_all=compute_all,
+                        features_std=p.features_std,
+                        features=p.features,
+                        get_raw_matrices=p.get_raw_matrices,
+                        log_buffer=log_buffer
                     )
 
                     total_time_accumulated += time_acc
-                    total_time_real         = time() - total_start_time
+                    total_time_real = time() - total_start_time
 
                     push!(log_buffer, "\n--- Label $label Summary ---")
                     push!(log_buffer, "Measured time of single function'sum (sum of @timed): $(total_time_accumulated) sec")
@@ -295,9 +295,9 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
     end
 
     img_to_use, mask_to_use = bounding_box(p.img, mask_to_use, p.verbose)
-    img_to_use, mask_to_use, spacing_to_use = squeeze_singleton_dims(img_to_use, mask_to_use, p.spacing)
+    img_to_use, mask_to_use, spacing_to_use = squeeze_unit_dimension(img_to_use, mask_to_use, p.spacing)
 
-    total_start_time       = time()
+    total_start_time = time()
     total_time_accumulated = 0.0
 
     if p.verbose
@@ -323,19 +323,19 @@ function extract_radiomic_features(img_input, mask_input, voxel_spacing_input;
 
     radiomic_features, time_acc = _compute_radiomics_impl(
         img_to_use, mask_to_use, spacing_to_use, voxel_count;
-        n_bins            = p.n_bins,
-        bin_width         = p.bin_width,
-        weighting_norm    = p.weighting_norm,
-        verbose           = p.verbose,
-        keep_largest_only = p.keep_largest_only,
-        features_std      = p.features_std,
-        compute_all       = compute_all,
-        features          = p.features,
-        get_raw_matrices  = p.get_raw_matrices
+        n_bins=p.n_bins,
+        bin_width=p.bin_width,
+        weighting_norm=p.weighting_norm,
+        verbose=p.verbose,
+        keep_largest_only=p.keep_largest_only,
+        features_std=p.features_std,
+        compute_all=compute_all,
+        features=p.features,
+        get_raw_matrices=p.get_raw_matrices
     )
 
     total_time_accumulated += time_acc
-    total_time_real         = time() - total_start_time
+    total_time_real = time() - total_start_time
 
     if p.verbose
         println("\n======================")
@@ -396,11 +396,11 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
     features_std::Bool=false,
     features::Vector{Symbol}=Symbol[],
     get_raw_matrices::Bool=false,
-    log_buffer::Union{Nothing,Vector{String}}=nothing)::Tuple{Dict{String,Any}, Float64}
-    
+    log_buffer::Union{Nothing,Vector{String}}=nothing)::Tuple{Dict{String,Any},Float64}
+
     radiomic_features = Dict{String,Any}()
     total_time_accumulated = 0.0
-    
+
     # Helper function to print or buffer log messages
     function log_println(msg::String)
         if isnothing(log_buffer)
@@ -440,7 +440,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
             (result.value, result.time)
         end
     end
-        
+
     # First order features
     if compute_all || :first_order in features
         t_first_order_features = Threads.@spawn begin
@@ -543,7 +543,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
 
     # First Order features
     if !isnothing(t_first_order_features)
-        first_order_dict, first_order_time = fetch(t_first_order_features)::Tuple{Dict{String,Any}, Float64}
+        first_order_dict, first_order_time = fetch(t_first_order_features)::Tuple{Dict{String,Any},Float64}
         merge!(radiomic_features, first_order_dict)
         total_time_accumulated += first_order_time
         if verbose
@@ -554,7 +554,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
 
     # GLCM features
     if !isnothing(t_glcm_features)
-        glcm_dict, glcm_time = fetch(t_glcm_features)::Tuple{Dict{String,Any}, Float64}
+        glcm_dict, glcm_time = fetch(t_glcm_features)::Tuple{Dict{String,Any},Float64}
         merge!(radiomic_features, glcm_dict)
         total_time_accumulated += glcm_time
         if verbose
@@ -564,10 +564,10 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
             end
         end
     end
-        
+
     # GLSZM features
     if !isnothing(t_glszm_features)
-        glszm_dict, glszm_time = fetch(t_glszm_features)::Tuple{Dict{String,Any}, Float64}
+        glszm_dict, glszm_time = fetch(t_glszm_features)::Tuple{Dict{String,Any},Float64}
         merge!(radiomic_features, glszm_dict)
         total_time_accumulated += glszm_time
         if verbose
@@ -580,7 +580,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
 
     # NGTDM features
     if !isnothing(t_ngtdm_features)
-        ngtdm_dict, ngtdm_time = fetch(t_ngtdm_features)::Tuple{Dict{String,Any}, Float64}
+        ngtdm_dict, ngtdm_time = fetch(t_ngtdm_features)::Tuple{Dict{String,Any},Float64}
         merge!(radiomic_features, ngtdm_dict)
         total_time_accumulated += ngtdm_time
         if verbose
@@ -593,7 +593,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
 
     # GLRLM features
     if !isnothing(t_glrlm_features)
-        glrlm_dict, glrlm_time = fetch(t_glrlm_features)::Tuple{Dict{String,Any}, Float64}
+        glrlm_dict, glrlm_time = fetch(t_glrlm_features)::Tuple{Dict{String,Any},Float64}
         merge!(radiomic_features, glrlm_dict)
         total_time_accumulated += glrlm_time
         if verbose
@@ -606,7 +606,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
 
     # GLDM features
     if !isnothing(t_gldm_features)
-        gldm_dict, gldm_time = fetch(t_gldm_features)::Tuple{Dict{String,Any}, Float64}
+        gldm_dict, gldm_time = fetch(t_gldm_features)::Tuple{Dict{String,Any},Float64}
         merge!(radiomic_features, gldm_dict)
         total_time_accumulated += gldm_time
         if verbose
@@ -620,7 +620,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
     # 3D shape features
     if ndims(mask) == 3
         if !isnothing(t_shape3d_features)
-            shape3d_dict, shape3d_time = fetch(t_shape3d_features)::Tuple{Dict{String,Any}, Float64}
+            shape3d_dict, shape3d_time = fetch(t_shape3d_features)::Tuple{Dict{String,Any},Float64}
             merge!(radiomic_features, shape3d_dict)
             total_time_accumulated += shape3d_time
             if verbose
@@ -633,7 +633,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
     # 2D shape features
     if ndims(mask) == 2
         if !isnothing(t_shape2d_features)
-            shape2d_dict, shape2d_time = fetch(t_shape2d_features)::Tuple{Dict{String,Any}, Float64}
+            shape2d_dict, shape2d_time = fetch(t_shape2d_features)::Tuple{Dict{String,Any},Float64}
             merge!(radiomic_features, shape2d_dict)
             total_time_accumulated += shape2d_time
             if verbose
@@ -642,7 +642,7 @@ function _compute_radiomics_impl(img::Array{Float64}, mask::BitArray, voxel_spac
             end
         end
     end
-    
+
     return (radiomic_features, total_time_accumulated)
 end
 
@@ -670,8 +670,8 @@ Base.@ccallable function c_extract_radiomic_features(
         # Call the main function
         c_features_dict = extract_radiomic_features(
             img, mask, spacing;
-            bin_width = binWidth,
-            verbose = false
+            bin_width=binWidth,
+            verbose=false
         )
 
         # Save the features in the global buffer
@@ -679,7 +679,7 @@ Base.@ccallable function c_extract_radiomic_features(
         return pointer(LAST_JSON_RESULT[])
 
     catch e
-        @error "Error during feature extraction step" exception=(e, catch_backtrace())
+        @error "Error during feature extraction step" exception = (e, catch_backtrace())
 
         err_msg = "{\"error\": \"$e\"}\0"
         LAST_JSON_RESULT[] = err_msg
@@ -692,12 +692,12 @@ end
 # - Reduces the TTFX (Time To First eXecution) for the package users.
 @setup_workload begin
     # Small synthetic data for precompilation warmup
-    img_small  = Float64.(reshape(1:1000, 10, 10, 10))
+    img_small = Float64.(reshape(1:1000, 10, 10, 10))
     mask_small = zeros(Float64, 10, 10, 10)
     mask_small[3:7, 3:7, 3:7] .= 1.0
 
     # Small 2D synthetic data for precompilation warmup
-    img_small_2d  = Float64.(reshape(1:100, 10, 10))
+    img_small_2d = Float64.(reshape(1:100, 10, 10))
     mask_small_2d = zeros(Float64, 10, 10)
     mask_small_2d[3:7, 3:7] .= 1.0
 
@@ -706,7 +706,7 @@ end
     mask_small_2d_multi = zeros(Float64, 10, 10)
     mask_small_2d_multi[3:7, 3:7] .= 1.0
     mask_small_2d_multi[6:8, 6:8] .= 2.0
-    
+
     # Multi-label mask
     mask_multi = zeros(Float64, 10, 10, 10)
     mask_multi[2:4, 2:4, 2:4] .= 1.0
@@ -714,59 +714,59 @@ end
 
     spacing = [1.0, 1.0, 1.0]
 
-    @compile_workload begin        
+    @compile_workload begin
         # 2D
         extract_radiomic_features(
             img_small_2d, mask_small_2d, spacing;
-            keep_largest_only = true,
-            verbose           = false
+            keep_largest_only=true,
+            verbose=false
         )
 
         # 2D mask multi-label
         extract_radiomic_features(
             img_small_2d_multi, mask_small_2d_multi, spacing;
-            keep_largest_only = false,
-            verbose           = false
+            keep_largest_only=false,
+            verbose=false
         )
 
         #2D label
         extract_radiomic_features(
             img_small_2d_multi, mask_small_2d_multi, spacing;
-            keep_largest_only = false,
-            labels            = [1,2],
-            verbose           = false
+            keep_largest_only=false,
+            labels=[1, 2],
+            verbose=false
         )
-        
+
         # --- Default bin_width ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            keep_largest_only = false,
-            verbose           = false
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- n_bins ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            n_bins            = 32,
-            keep_largest_only = false,
-            verbose           = false
+            n_bins=32,
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- bin_width explicit ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            bin_width         = 25.0,
-            keep_largest_only = false,
-            verbose           = false
+            bin_width=25.0,
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- Weighting norms ---
         for wn in ["euclidean", "infinity", "manhattan", "no_weighting"]
             extract_radiomic_features(
                 img_small, mask_small, spacing;
-                weighting_norm    = wn,
-                keep_largest_only = false,
-                verbose           = false
+                weighting_norm=wn,
+                keep_largest_only=false,
+                verbose=false
             )
         end
 
@@ -784,66 +784,66 @@ end
         ]
             extract_radiomic_features(
                 img_small, mask_small, spacing;
-                features          = feat,
-                keep_largest_only = false,
-                verbose           = false
+                features=feat,
+                keep_largest_only=false,
+                verbose=false
             )
         end
 
         # --- keep_largest_only = true ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            keep_largest_only = true,
-            verbose           = false
+            keep_largest_only=true,
+            verbose=false
         )
 
         # --- features_std = true ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            features          = [:glrlm],
-            features_std      = true,
-            keep_largest_only = false,
-            verbose           = false
+            features=[:glrlm],
+            features_std=true,
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- Multi-label ---
         extract_radiomic_features(
             img_small, mask_multi, spacing;
-            labels            = [1, 2],
-            keep_largest_only = false,
-            verbose           = false
+            labels=[1, 2],
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- Single explicit label ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            labels            = 1,
-            keep_largest_only = false,
-            verbose           = false
+            labels=1,
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- get_raw_matrices ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            get_raw_matrices  = true,
-            keep_largest_only = false,
-            verbose           = false
+            get_raw_matrices=true,
+            keep_largest_only=false,
+            verbose=false
         )
 
         # --- 2D slice extraction ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            slices_2d         = [(1, 5)],
-            keep_largest_only = true,
-            verbose           = false
+            slices_2d=[(1, 5)],
+            keep_largest_only=true,
+            verbose=false
         )
 
         # --- Multiple slices ---
         extract_radiomic_features(
             img_small, mask_small, spacing;
-            slices_2d         = [(1, 5), (2, 5), (3, 5)],
-            keep_largest_only = false,
-            verbose           = false
+            slices_2d=[(1, 5), (2, 5), (3, 5)],
+            keep_largest_only=false,
+            verbose=false
         )
     end
 end

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -17,9 +17,9 @@
     - `cropped_img`: image array cropped to the bounding box of the mask.
     - `cropped_mask`: binary mask array (`BitArray`) cropped to the same bounding box."""
 function bounding_box(img::AbstractArray{Float64},
-                       mask::AbstractArray,
-                       verbose::Bool;
-                       log_buffer::Union{Vector{String},Nothing}=nothing)::Tuple{AbstractArray{Float64}, BitArray}
+    mask::AbstractArray,
+    verbose::Bool;
+    log_buffer::Union{Vector{String},Nothing}=nothing)::Tuple{AbstractArray{Float64},BitArray}
     function _bb_log(msg)
         if !isnothing(log_buffer)
             push!(log_buffer, msg)
@@ -42,14 +42,18 @@ function bounding_box(img::AbstractArray{Float64},
 
     for i in idx
         for d in 1:n
-            if i[d] < mins[d]; mins[d] = i[d]; end
-            if i[d] > maxs[d]; maxs[d] = i[d]; end
+            if i[d] < mins[d]
+                mins[d] = i[d]
+            end
+            if i[d] > maxs[d]
+                maxs[d] = i[d]
+            end
         end
     end
 
     ranges = [mins[d]:maxs[d] for d in 1:n]
 
-    cropped_img  = img[ranges...]
+    cropped_img = img[ranges...]
     cropped_mask = mask[ranges...]
 
     if verbose
@@ -63,18 +67,18 @@ function bounding_box(img::AbstractArray{Float64},
 end
 
 """
-    squeeze_singleton_dims(img, mask, voxel_spacing)
+    squeeze_unit_dimension(img, mask, voxel_spacing)
 
     If the image/mask is 3D but has a singleton dimension (size 1 along one axis),
     drops that dimension and returns 2D arrays with adjusted spacing.
     Otherwise returns the inputs unchanged.
 """
-function squeeze_singleton_dims(img::AbstractArray{Float64}, mask::BitArray, voxel_spacing::Vector{Float64})::Tuple{AbstractArray{Float64}, BitArray, Vector{Float64}}
+function squeeze_unit_dimension(img::AbstractArray{Float64}, mask::BitArray, voxel_spacing::Vector{Float64})::Tuple{AbstractArray{Float64},BitArray,Vector{Float64}}
     if ndims(mask) == 3 && any(size(mask) .== 1)
         squeeze_dim = findfirst(==(1), size(mask))
-        img_out  = dropdims(img,  dims=squeeze_dim)
+        img_out = dropdims(img, dims=squeeze_dim)
         mask_out = dropdims(mask, dims=squeeze_dim)
-        spacing_out = voxel_spacing[setdiff(1:3, squeeze_dim)]
+        spacing_out = [voxel_spacing[d] for d in 1:3 if d != squeeze_dim]
         return img_out, mask_out, spacing_out
     else
         return img, mask, voxel_spacing
@@ -179,7 +183,7 @@ function discretize_image(img::AbstractArray{Float64},
     n_bins::Union{Int,Nothing}=nothing,
     bin_width::Union{Float64,Nothing}=nothing,
     vmin::Union{Float64,Nothing}=nothing,
-    vmax::Union{Float64,Nothing}=nothing)::Tuple{Array{Int}, Int, Vector{Int}, Float64}
+    vmax::Union{Float64,Nothing}=nothing)::Tuple{Array{Int},Int,Vector{Int},Float64}
 
     if sum(mask) == 0
         return zeros(Int, size(img)), 0, Int[], 0.0
@@ -243,7 +247,7 @@ end
     # Returns:
         - The mask containing only the largest connected component (Array).
     """
-function keep_largest_component(mask::AbstractArray{Bool})::Tuple{AbstractArray{Bool}, Int}
+function keep_largest_component(mask::AbstractArray{Bool})::Tuple{AbstractArray{Bool},Int}
     if sum(mask) == 0
         return mask, 0  # Restituisce anche 0 isole
     end
@@ -317,23 +321,23 @@ end
         # Returns:
         - Nothing. Prints the features to the console."""
 function print_features(title::String,
-                         features::Dict{String,Any};
-                         log_buffer::Union{Vector{String},Nothing}=nothing)::Nothing
+    features::Dict{String,Any};
+    log_buffer::Union{Vector{String},Nothing}=nothing)::Nothing
     output = String[]
-    
+
     push!(output, "\n--- $title ---")
-    
-    base_keys = sort([k for k in keys(features) 
-                       if !endswith(k, "_std") && !endswith(k, "_min") && !endswith(k, "_max")])
-    
+
+    base_keys = sort([k for k in keys(features)
+                      if !endswith(k, "_std") && !endswith(k, "_min") && !endswith(k, "_max")])
+
     for (i, k) in enumerate(base_keys)
         val = features[k]
         std_key = k * "_std"
         min_key = k * "_min"
         max_key = k * "_max"
-        
+
         padded_key = rpad(k, 42)
-        
+
         if haskey(features, std_key)
             std_val = features[std_key]
             min_val = features[min_key]
@@ -343,10 +347,10 @@ function print_features(title::String,
             push!(output, "  $i. $(padded_key) => $val")
         end
     end
-    
+
     push!(output, "Subtotal: $(length(base_keys)) features")
     push!(output, "---------------------\n")
-    
+
     if isnothing(log_buffer)
         for line in output
             println(line)
@@ -378,35 +382,35 @@ function _cast_inputs(
     bin_width,
     weighting_norm,
     features_std,
-    slices_2d,          
-    keep_largest_only,  
-    get_raw_matrices,   
-    verbose             
-    )::NamedTuple{
-        (:img, :mask, :spacing, :features, :labels, :n_bins, :bin_width, :weighting_norm, :features_std, :slices_2d, :keep_largest_only, :get_raw_matrices, :verbose),
-        Tuple{
-            Union{Array{Float64,2}, Array{Float64,3}},
-            Union{Array{Int,2}, Array{Int,3}},
-            Vector{Float64},
-            Vector{Symbol},
-            Union{Int, Vector{Int}},
-            Union{Nothing, Int},
-            Union{Nothing, Float64},
-            Union{Nothing, String}, 
-            Bool,
-            Union{Nothing, Vector{Tuple{Int,Int}}},
-            Bool,                                     
-            Bool,                                     
-            Bool                                      
-        }
+    slices_2d,
+    keep_largest_only,
+    get_raw_matrices,
+    verbose
+)::NamedTuple{
+    (:img, :mask, :spacing, :features, :labels, :n_bins, :bin_width, :weighting_norm, :features_std, :slices_2d, :keep_largest_only, :get_raw_matrices, :verbose),
+    Tuple{
+        Union{Array{Float64,2},Array{Float64,3}},
+        Union{Array{Int,2},Array{Int,3}},
+        Vector{Float64},
+        Vector{Symbol},
+        Union{Int,Vector{Int}},
+        Union{Nothing,Int},
+        Union{Nothing,Float64},
+        Union{Nothing,String},
+        Bool,
+        Union{Nothing,Vector{Tuple{Int,Int}}},
+        Bool,
+        Bool,
+        Bool
     }
+}
 
     # --- Perpare input ---
     #For img
     # 2D input: convert to 2D Float64 array
-    img::Union{Array{Float64,2}, Array{Float64,3}} = if ndims(img_input) == 2
+    img::Union{Array{Float64,2},Array{Float64,3}} = if ndims(img_input) == 2
         convert(Array{Float64,2}, img_input)
-    # 3D input: convert to 3D Float64 array
+        # 3D input: convert to 3D Float64 array
     elseif ndims(img_input) == 3
         convert(Array{Float64,3}, img_input)
     else
@@ -415,9 +419,9 @@ function _cast_inputs(
 
     # For Mask
     # 2D input: convert to 2D Float64 array
-    mask::Union{Array{Int,2}, Array{Int,3}} = if ndims(mask_input) == 2
+    mask::Union{Array{Int,2},Array{Int,3}} = if ndims(mask_input) == 2
         convert(Array{Int,2}, mask_input)
-    # 3D input: convert to 3D Float64 array
+        # 3D input: convert to 3D Float64 array
     elseif ndims(mask_input) == 3
         convert(Array{Int,3}, mask_input)
     else
@@ -431,7 +435,7 @@ function _cast_inputs(
 
     #Sanity Check
     if size(img) != size(mask)
-         throw(ArgumentError("img and mask have different size!"))
+        throw(ArgumentError("img and mask have different size!"))
     end
 
     # Convert spacing (supports any numeric vector/list)
@@ -474,26 +478,26 @@ function _cast_inputs(
     weighting_norm_out::Union{Nothing,String} = isnothing(weighting_norm) ? nothing : String(weighting_norm)
 
     #Convert slices_2d
-    slices_2d_out::Union{Nothing, Vector{Tuple{Int,Int}}} = if isnothing(slices_2d)
+    slices_2d_out::Union{Nothing,Vector{Tuple{Int,Int}}} = if isnothing(slices_2d)
         nothing
     else
         Tuple{Int,Int}[(Int(s[1]), Int(s[2])) for s in slices_2d]
     end
 
     return (
-        img            = img,
-        mask           = mask,
-        spacing        = spacing,
-        features       = features_out,
-        labels         = labels_out,
-        n_bins         = n_bins_out,
-        bin_width      = bin_width_out,
-        weighting_norm = weighting_norm_out,
-        features_std   = Bool(features_std),
-        slices_2d      = slices_2d_out,
-        keep_largest_only = Bool(keep_largest_only),
-        get_raw_matrices  = Bool(get_raw_matrices),
-        verbose           = Bool(verbose)
+        img=img,
+        mask=mask,
+        spacing=spacing,
+        features=features_out,
+        labels=labels_out,
+        n_bins=n_bins_out,
+        bin_width=bin_width_out,
+        weighting_norm=weighting_norm_out,
+        features_std=Bool(features_std),
+        slices_2d=slices_2d_out,
+        keep_largest_only=Bool(keep_largest_only),
+        get_raw_matrices=Bool(get_raw_matrices),
+        verbose=Bool(verbose)
     )
 end
 
@@ -506,8 +510,8 @@ end
         # Returns:
         - Nothing. Prints a warning if the binning parameters are invalid."""
 function validate_binning_parameters(img_input::AbstractArray{Float64},
-                                      mask_input::BitArray,
-                                      bin_width::Float64)::Nothing
+    mask_input::BitArray,
+    bin_width::Float64)::Nothing
 
     # Calculate range and estimated number of bins
     roi_vals = img_input[mask_input]
@@ -534,14 +538,14 @@ end
         # Returns:
         - A tuple containing the extracted mask and the voxel count."""
 function extract_and_check_mask(mask_input::AbstractArray{Int},
-                                 label::Int)::Tuple{BitArray, Int}
+    label::Int)::Tuple{BitArray,Int}
     mask_to_use = (mask_input .== label)
     # Check if label exists
     voxel_count = sum(mask_to_use)
     if voxel_count == 0
         @warn "Label $label not found in mask (no voxels with this value). Skipping."
     end
-    
+
     return mask_to_use, voxel_count
 
 end

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -76,6 +76,7 @@ end
 function squeeze_unit_dimension(img::AbstractArray{Float64}, mask::BitArray, voxel_spacing::Vector{Float64})::Tuple{AbstractArray{Float64},BitArray,Vector{Float64}}
     if ndims(mask) == 3 && any(size(mask) .== 1)
         squeeze_dim = findfirst(==(1), size(mask))
+        @warn "Detected a unit dimension (size 1) along axis $squeeze_dim in a 3D array of size $(size(mask)). Squeezing to 2D and computing 2D features instead of 3D."
         img_out = dropdims(img, dims=squeeze_dim)
         mask_out = dropdims(mask, dims=squeeze_dim)
         spacing_out = [voxel_spacing[d] for d in 1:3 if d != squeeze_dim]

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -63,6 +63,25 @@ function bounding_box(img::AbstractArray{Float64},
 end
 
 """
+    squeeze_singleton_dims(img, mask, voxel_spacing)
+
+    If the image/mask is 3D but has a singleton dimension (size 1 along one axis),
+    drops that dimension and returns 2D arrays with adjusted spacing.
+    Otherwise returns the inputs unchanged.
+"""
+function squeeze_singleton_dims(img::AbstractArray{Float64}, mask::BitArray, voxel_spacing::Vector{Float64})::Tuple{AbstractArray{Float64}, BitArray, Vector{Float64}}
+    if ndims(mask) == 3 && any(size(mask) .== 1)
+        squeeze_dim = findfirst(==(1), size(mask))
+        img_out  = dropdims(img,  dims=squeeze_dim)
+        mask_out = dropdims(mask, dims=squeeze_dim)
+        spacing_out = voxel_spacing[setdiff(1:3, squeeze_dim)]
+        return img_out, mask_out, spacing_out
+    else
+        return img, mask, voxel_spacing
+    end
+end
+
+"""
     label_components(mask::AbstractArray{Bool})::Array{Int}
 
     Labels connected components in a binary mask using 26-connectivity for 3D
@@ -83,26 +102,6 @@ function label_components(mask::AbstractArray{Bool})::Array{Int}
     dims = size(mask)
     lin_indices = LinearIndices(dims)
     cart_indices = CartesianIndices(dims)
-
-    # 3D offsets for 26-connectivity, or 2D for 8-connectivity
-    # We'll generate them dynamically to handle generic dims
-    offsets = Int[]
-    if ndims(mask) == 3
-        for z in -1:1, y in -1:1, x in -1:1
-            (x == 0 && y == 0 && z == 0) && continue
-            push!(offsets, lin_indices[CartesianIndex(x + 2, y + 2, z + 2)] - lin_indices[CartesianIndex(2, 2, 2)])
-        end
-    elseif ndims(mask) == 2
-        for y in -1:1, x in -1:1
-            (x == 0 && y == 0) && continue
-            push!(offsets, lin_indices[CartesianIndex(x + 2, y + 2)] - lin_indices[CartesianIndex(2, 2)])
-        end
-    end
-    # Note: The above offset calculation is a bit tricky with edge cases if not careful 
-    # about bounds. It's safer to use CartesianIndices for bounds checking or 
-    # standard neighbor iteration. 
-    # Let's stick to a robust standard BFS with CartesianIndices to ensure correctness 
-    # at edges, similar to the existing get_neighbors but optimized for the queue.
 
     @inbounds for i in eachindex(mask)
         if mask[i] && labels[i] == 0


### PR DESCRIPTION
## Fix: Handle unit-size dimensions (size 1) in 3D masks/images

### Problem

Two distinct issues, both related to 3D masks/images with a dimension of size 1 along one axis (e.g. `(8, 8, 1)`):

1. **Crash in `label_components`** (`utils.jl`): a `BoundsError` was raised whenever a mask dimension had size 1. The crash originated from dead code that precomputed neighbor offsets using a fixed reference point, `CartesianIndex(2,2,2)`, which is out of bounds on any axis with size < 2.

2. **Incorrect 2D/3D classification**: a 3D array with a unit dimension was still routed through the 3D computation path (based on `ndims(mask) == 3`), producing physically meaningless features (e.g. `shape3d_flatness => NaN`) even when it did not crash. This occurs both with natively flat volumes (e.g. a single slice saved as an `(X, Y, 1)` NIfTI) and with normal volumes whose bounding box is reduced to a single slice after cropping around the ROI.

### Fix

**1. `label_components`** — removed the dead code block responsible for the crash. The existing flood-fill implementation, based on `CartesianIndices` and `checkbounds`, is already inherently safe for any array dimension and did not depend on the removed, unused optimization.

**2. New function `squeeze_unit_dimension`** (`utils.jl`) — detects a 3D array with a unit dimension, removes it via `dropdims`, and adjusts the voxel spacing accordingly. It is called immediately after `bounding_box`, in both the single-label and multi-label paths of `extract_radiomic_features`, so the array is automatically routed through the 2D computation path, exactly as if it had been passed manually via `slices_2d`. No effect on arrays that are already 2D or fully 3D (no-op in those cases).

An explicit `@warn` was added to surface this behavior when the squeeze is applied, to keep it visible during batch processing.

```julia
function squeeze_unit_dimension(img::AbstractArray{Float64}, mask::BitArray, voxel_spacing::Vector{Float64})::Tuple{AbstractArray{Float64},BitArray,Vector{Float64}}
    if ndims(mask) == 3 && any(size(mask) .== 1)
        squeeze_dim = findfirst(==(1), size(mask))
        @warn "Detected a unit dimension (size 1) along axis $squeeze_dim in a 3D array of size $(size(mask)). Squeezing to 2D and computing 2D features instead of 3D."
        img_out = dropdims(img, dims=squeeze_dim)
        mask_out = dropdims(mask, dims=squeeze_dim)
        spacing_out = [voxel_spacing[d] for d in 1:3 if d != squeeze_dim]
        return img_out, mask_out, spacing_out
    else
        return img, mask, voxel_spacing
    end
end
```

`_compute_radiomics_impl` is unchanged and remains type-stable: it always receives `img`/`mask` already in their final form, with no dimensionality change occurring inside it.

### Verification

Tested on three scenarios:

| Scenario | Input | After bounding_box | Path taken | Outcome |
|---|---|---|---|---|
| Natively flat volume (real NIfTI file) | `(8,8,1)` | `(8,8,1)` -> squeeze -> `(8,8)` | 2D | 119 features extracted, no crash |
| Native 2D mask | `(20,20)` | `(11,11)` | 2D | 119 features extracted, no crash |
| ROI confined to a single slice within a normal volume | `(50,50,20)` | `(13,13,1)` -> squeeze -> `(13,13)` | 2D | 119 features extracted, no crash |

In all three cases: no crash, no `NaN` features, correct 2D path selection, and shape feature values (`shape2d_sphericity`, `shape2d_perimeter`, etc.) consistent and physically sensible.

The fix was further validated by comparing results against manual extraction via `slices_2d`, yielding identical values.